### PR TITLE
Use debug module instead of console logging

### DIFF
--- a/Mockgoose.js
+++ b/Mockgoose.js
@@ -1,5 +1,5 @@
 'use strict';
-var logger = require('nodelogger').Logger(__filename);
+var debug = require('debug')('mockgoose:main');
 var _ = require('lodash');
 
 var mock = require('./lib/Model');
@@ -51,7 +51,7 @@ module.exports = function (mongoose) {
             options = {};
         }
 
-        logger.info('Creating Mockgoose database: ', database, ' options: ', options);
+        debug('Creating Mockgoose database: ' + database + ' options: ' + options);
         var connection = mongoose.originalConnection.call(mongoose, database, options, function () {
             if (callback) {
                 //Always return true as we are faking it.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,5 @@
 'use strict';
-var logger = require('nodelogger').Logger(__filename);
+var debug = require('debug')('mockgoose:utils');
 var _ = require('lodash');
 module.exports.isEmpty = _.isEmpty;
 module.exports.objectToArray = objectToArray;
@@ -46,7 +46,7 @@ function cloneItem(item) {
     if (item.mockModel) {
         return new item.mockModel(item);
     } else {
-        logger.warn('Returning actual model this may be mutated!');
+        debug('Returning actual model this may be mutated!');
         return item;
     }
 }
@@ -236,7 +236,7 @@ function cloneItem(item) {
     if (item.mockModel) {
         return new item.mockModel(item);
     } else {
-        logger.warn('Returning actual model this may be mutated!');
+        debug('Returning actual model this may be mutated!');
         return item;
     }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "node": ">=0.6.19"
   },
   "dependencies": {
-    "nodelogger": "https://github.com/mccormicka/nodelogger/archive/master.tar.gz",
+    "debug": "latest",
     "mongoosemask": "https://github.com/mccormicka/mongoosemask/archive/master.tar.gz",
     "lodash": "~2.1.0"
   },


### PR DESCRIPTION
This library should never directly log to console. Moving to debug.

https://github.com/visionmedia/debug#usage

You can watch these debug messages by running your application with 
`DEBUG=mockgoose:* node .`

If you want real logging, take a look at https://github.com/flatiron/winston#usage
