### PR TITLE
After cloning in order to run `npm test` the dependencies of jasmine-node need to be installed.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "in memory"
   ],
   "scripts": {
+    "postinstall": "if [ -d node_modules/jasmine-node ]; then cd node_modules/jasmine-node && npm install; fi",
     "test": "./node_modules/jasmine-node/bin/jasmine-node test/ --verbose --color --captureExceptions"
   },
   "main": "Mockgoose",


### PR DESCRIPTION
This script will install them automatically in development environment after `npm install`
