### PR TITLE
fix; Model.count takes a second options argument

### DIFF
--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -169,8 +169,8 @@ function Collection(mongoCollection, Model) {
         });
     };
 
-    this.count = function (conditions, callback) {
-        this.find(conditions, {}, function (err, results) {
+    this.count = function (conditions, options, callback) {
+        this.find(conditions, options, function (err, results) {
             if (err) {
                 return callback(err);
             }


### PR DESCRIPTION
This fixes the issue #10 for me.  Perhaps Mongoose added that argument in a newer version?  I wasn't able to get the test runner to run for some reason otherwise I would have double checked those.
