### PR TITLE
Set log level with environment variable, fixes #19

### DIFF
--- a/lib/Logger.js
+++ b/lib/Logger.js
@@ -2,6 +2,11 @@
 
 var bunyan = require('bunyan');
 
-exports = module.exports = (function Logger(){
-    return bunyan.createLogger({name:'Mockgoose'});
+exports = module.exports = (function Logger() {
+    var logLevel = process.env['BUNYAN_LOG_LEVEL'] || 'warn';
+    return bunyan.createLogger({
+        name:'Mockgoose',
+        stream: process.stdout,
+        level: logLevel
+    });
 })();


### PR DESCRIPTION
Default log level now set to warn.
Other log levels can be set by setting the BUNYAN_LOG_LEVEL environment variable.
For example:
`BUNYAN_LOG_LEVEL=info node .`
or
`BUNYAN_LOG_LEVEL=error npm test`
