### PR TITLE
Fixes exception with the Count operation

### DIFF
--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -186,6 +186,26 @@ function Collection(mongoCollection, Model) {
         });
     };
 
+    this.distinct = function (distinctProperty, conditions, options, callback) {
+        if (typeof options === 'function') {
+            callback = options;
+            options = {};
+        }
+        this.find(conditions, options, function (err, results) {
+            if (err) {
+                return callback(err);
+            }
+            results.toArray(function (err, results) {
+                var distinctArray = _.uniq(results, distinctProperty),
+                    distinctPropArray = [];
+
+                distinctArray.forEach(function (item) {
+                    distinctPropArray.push(item[distinctProperty]);
+                });
+                callback(err, distinctPropArray);
+            });
+        });
+    };
 
     //-------------------------------------------------------------------------
     //


### PR DESCRIPTION
If options was not present, it was trying to use options as callback. It simply
checks if options was passed in or not and initializes options to {}.

Resolves mccormicka/Mockgoose#48
