### PR TITLE
Fixes exception with the Count operation

### DIFF
--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -172,6 +172,10 @@ function Collection(mongoCollection, Model) {
     };
 
     this.count = function (conditions, options, callback) {
+        if (typeof options === 'function') {
+            callback = options;
+            options = {};
+        }
         this.find(conditions, options, function (err, results) {
             if (err) {
                 return callback(err);


### PR DESCRIPTION
If options was not present, it was trying to use options as callback. It simply
checks if options was passed in or not and initializes options to {}.

Resolves mccormicka/Mockgoose#48
