### PR TITLE
Fixes a problem with $or operations on non object arrays

### DIFF
--- a/lib/operations/logical/OrOperation.js
+++ b/lib/operations/logical/OrOperation.js
@@ -19,7 +19,11 @@ module.exports = function operation(model, update, options) {
                 valid = _.isEqual(utils.findNestedValue(model, key), item);
             }
             else {
-                valid = _.isEqual(model[key], item);
+                if (_.isArray(model[key])) {
+                    valid = _.some(model[key], function(v) { return _.isEqual(v, item) });
+                } else {
+                    valid = _.isEqual(model[key], item);
+                }
             }
         });
         return valid;


### PR DESCRIPTION
Fixes an issue that prevent normal query operations for $or against
arrays on non objects , like ['1','2','3']
