### PR TITLE
Fixes $or operations on non object arrays

### DIFF
--- a/lib/operations/logical/OrOperation.js
+++ b/lib/operations/logical/OrOperation.js
@@ -19,7 +19,11 @@ module.exports = function operation(model, update, options) {
                 valid = _.isEqual(utils.findNestedValue(model, key), item);
             }
             else {
-                valid = _.isEqual(model[key], item);
+                if (_.isArray(model[key])) {
+                    valid = _.some(model[key], function(v) { return _.isEqual(v, item); });
+                } else {
+                    valid = _.isEqual(model[key], item);
+                }
             }
         });
         return valid;

--- a/test/operations/logical/OrOperation.spec.js
+++ b/test/operations/logical/OrOperation.spec.js
@@ -11,6 +11,7 @@ describe('Mockgoose $or Tests', function () {
         price: Number,
         qty: Number,
         sale: Boolean,
+        historyprice: [Number],
         carrier: {
             state: String
         }
@@ -23,12 +24,14 @@ describe('Mockgoose $or Tests', function () {
             {
                 price: 1.99,
                 qty: 20,
-                sale: true
+                sale: true,
+                historyprice: [1.90, 1.77, 1.50]
             },
             {
                 price: 1.99,
                 qty: 50,
-                sale: true
+                sale: true,
+                historyprice: [1.85, 1.60, 1.40]
             },
             {
                 price: 1.99,
@@ -42,11 +45,13 @@ describe('Mockgoose $or Tests', function () {
             }, {
                 price: 1,
                 qty: 21,
-                sale: false
+                sale: false,
+                historyprice: [0.99]
             }, {
                 price: 10,
                 qty: 21,
-                sale: false
+                sale: false,
+                historyprice: [8.99, 7.99]
             }, {
                 carrier: {
                     state: 'NY'
@@ -112,6 +117,16 @@ describe('Mockgoose $or Tests', function () {
                 { sale: true }
             ], qty: { $in: [20, 50] } }).exec().then(function (results) {
                 expect(results.length).toBe(2);
+                done();
+            });
+        });
+
+        it('$or in an array of values', function (done) {
+            Model.find({ $or: [ 
+                { historyprice: 8.99 },
+                { price: 1.99 }
+            ]}).exec().then(function(results) {
+                expect(results.length).toBe(5);
                 done();
             });
         });


### PR DESCRIPTION
Fixes an issue that prevent normal query operations for $or against
arrays on non objects , like ['1','2','3']
