### PR TITLE
Fixed tests for testing issue #58

### DIFF
--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -48,14 +48,28 @@ describe('Index Tests', function () {
 
     describe('Bugs', function () {
 
+        // create a model to work on
+        mongoose.model('indexUniqueModel', new mongoose.Schema({
+            name: { type: String, index: { unique: true } }
+        }));
+        var IndexUniqueModel = mongoose.model('indexUniqueModel'),
+            NAME = 'Vlad Impaler';
+
         ddescribe('#58 https://github.com/mccormicka/Mockgoose/issues/58', function () {
             it('Support duplicate validation on `index: { unique: true} }`', function (done) {
                 expect(function () {
-                    new mongoose.Schema({
-                        index: {unique: true}
-                    });
+                    IndexUniqueModel.create({ name: NAME });
                 }).not.toThrow();
-                done();
+                expect(function () {
+                    IndexUniqueModel.create({ name: NAME });
+                }).toThrow();
+                IndexUniqueModel.create({ name: NAME }, function (err) {
+                    expect(err).not.toBe(null);
+                    if ( err ) {
+                        expect(err.code).toBe(11000);
+                    }
+                    done();
+                });
             });
 
         });


### PR DESCRIPTION
Fixed tests to test specifically this issue.

Notice that while connected to  mongod, the console logs:

```
  background addExistingToIndex exception E11000 duplicate key error index: TestingDB.indexuniquemodels.$name_1  dup key: { : "Vlad Impaler" }
```

Also note what the [Mongoose docs say](http://mongoosejs.com/docs/api.html#schematype_SchemaType-unique) about this error:

> NOTE: violating the constraint returns an E11000 error from MongoDB when saving, not a Mongoose validation error.

So the error is raised anyhow, only it's coming directly from mongo, if it matters (I guess not, but just to be sure).
