### PR TITLE
Fix require of mockgoose in sample usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To run the tests and see what is supported by Mockgoose navigate to the Mockgoos
 You simply require Mongoose and Mockgoose and wrap Mongoose with Mockgoose.
 
     var mongoose = require('mongoose');
-    var mockgoose = require('Mockgoose');
+    var mockgoose = require('mockgoose');
 
     mockgoose(mongoose);
 


### PR DESCRIPTION
Just a tiny tweak to the README.md file.  I actually copy/pasted that code into one of my projects.  For some reason it ran fine locally, but broke on my CI server since the npm package name is all lower-case.
