### PR TITLE
add option.overwrite support in update

### DIFF
--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -250,8 +250,23 @@ function Collection(mongoCollection, Model) {
     }
 
     function updateResult(result, update, options) {
+        // Empty the result before doing anything if options.overwrite is true
+        if (options.overwrite === true) {
+            _.forIn(result, function (val, key) {
+                if (key !== '_id') {
+                    delete result[key];
+                }
+            });
+        }
+
         _.forIn(update, function (update, type) {
-            getOperation(type)(result, update, options);
+            if (type[0] === '$')
+                getOperation(type)(result, update, options);
+            else {
+                var set = {};
+                set[type] = update;
+                getOperation('$set')(result, set, options);
+            }
         });
     }
 }

--- a/test/Update.spec.js
+++ b/test/Update.spec.js
@@ -84,6 +84,53 @@ describe('Mockgoose Update Tests', function () {
         });
     });
 
+    describe('options.overwrite', function () {
+
+        it('should be able to overwrite items', function (done) {
+            AccountModel.create({email: 'testing@testing.com', password: 'password', values: ['one', 'two']}, function (err, model) {
+                expect(model).toBeDefined();
+                if (model) {
+                    AccountModel.update({email: 'testing@testing.com'}, {email: 'updated@testing.com'}, {overwrite: true}, function (err, result) {
+                        expect(result).toBe(1);
+                        AccountModel.findOne({email: 'updated@testing.com'}, function (err, result) {
+                            if (result) {
+                                expect(result.email).toBe('updated@testing.com');
+                                expect(result.password).toBeUndefined();
+                                expect(result.values.length).toBe(0);
+                                done(err);
+                            } else {
+                                done('Error finding models');
+                            }
+                        });
+                    });
+                } else {
+                    done(err);
+                }
+            });
+        });
+
+        it('should have the same _id after overwriting an item', function (done) {
+            AccountModel.create({email: 'testing@testing.com', password: 'password', values: ['one', 'two']}, function (err, model) {
+                expect(model).toBeDefined();
+                if (model) {
+                    model.update({email: 'updated@testing.com'}, {overwrite: true}, function (err, result) {
+                        expect(result).toBe(1);
+                        AccountModel.findOne({_id: model._id}, function (err, result) {
+                            expect(result).toBeDefined();
+                            if (result) {
+                                expect(result.email).toBe('updated@testing.com');
+                            }
+                            done(err);
+                        });
+                    });
+                } else {
+                    done(err);
+                }
+
+            });
+        });
+    });
+
     describe('$pull', function () {
 
         it('should be able to pull items from nested documents array', function (done) {

--- a/test/operations/PullAllOperation.spec.js
+++ b/test/operations/PullAllOperation.spec.js
@@ -1,7 +1,7 @@
 describe('Mockgoose Update Tests', function () {
     'use strict';
 
-    var mockgoose = require('../../../Mockgoose');
+    var mockgoose = require('./../../Mockgoose');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/operations/PullOperation.spec.js
+++ b/test/operations/PullOperation.spec.js
@@ -1,7 +1,7 @@
 describe('Mockgoose Update Tests', function () {
     'use strict';
 
-    var mockgoose = require('../../../Mockgoose');
+    var mockgoose = require('./../../Mockgoose');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/operations/PushAllOperation.spec.js
+++ b/test/operations/PushAllOperation.spec.js
@@ -1,7 +1,7 @@
 describe('Mockgoose Update Tests', function () {
     'use strict';
 
-    var mockgoose = require('../../../Mockgoose');
+    var mockgoose = require('./../../Mockgoose');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/operations/PushOperation.spec.js
+++ b/test/operations/PushOperation.spec.js
@@ -1,7 +1,7 @@
 describe('Mockgoose Update Tests', function () {
     'use strict';
 
-    var mockgoose = require('../../../Mockgoose');
+    var mockgoose = require('./../../Mockgoose');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);


### PR DESCRIPTION
This add support for update operation as described in issue #78.

I also patched 4 test files that were getting out of the project and expecting its folder to be called Mockgoose (I called mine `mockgoose` in small caps and it was making tests fail on Linux since ext4 is case sensitive).