### PR TITLE
projections can have mixed includes and excludes if excludes is only _id

### DIFF
--- a/lib/options/Filter.js
+++ b/lib/options/Filter.js
@@ -28,9 +28,11 @@ module.exports = function filterFields(fields, results) {
         }
     }
     if(includes.length && excludes.length ){
-        var error = new Error('You cannot currently mix including and excluding fields. Contact us if this is an issue.');
-        error.name = 'MongoError';
-        return error;
+        if(excludes.length !== 1 || excludes.indexOf('_id') === -1 ) {
+            var error = new Error('You cannot currently mix including and excluding fields. Contact us if this is an issue.');
+            error.name = 'MongoError';
+            return error;
+        }
     }
 
     if (includes.length || excludes.length) {

--- a/test/Find.spec.js
+++ b/test/Find.spec.js
@@ -255,6 +255,16 @@ describe('Mockgoose Find Tests', function () {
             });
         });
 
+        it('Should not throw an error if you pass include with only _id exclude object', function (done) {
+            SimpleModel.create({name: 'fields', value: 'one', type: 'blue', bool: 1}, function () {
+                SimpleModel.findOne({type: 'blue'}, {value: 1, _id: 0}, function (err, model) {
+                    expect(err).toBeFalsy();
+                    expect(model).toBeDefined();
+                    done();
+                });
+            });
+        });
+
         it('Should throw an error if you pass a mixed include/exclude string', function (done) {
             SimpleModel.create({name: 'fields', value: 'one', type: 'blue', bool: 1}, function () {
                 SimpleModel.findOne({type: 'blue'}, '-name value type -bool', function (err, model) {
@@ -264,6 +274,16 @@ describe('Mockgoose Find Tests', function () {
                         expect(err.message).toBe('You cannot currently mix including and excluding fields. Contact us if this is an issue.');
                     }
                     expect(model).toBeUndefined();
+                    done();
+                });
+            });
+        });
+
+        it('Should not throw an error if you pass include with only _id exclude string', function (done) {
+            SimpleModel.create({name: 'fields', value: 'one', type: 'blue', bool: 1}, function () {
+                SimpleModel.findOne({type: 'blue'}, 'value -_id', function (err, model) {
+                    expect(err).toBeFalsy();
+                    expect(model).toBeDefined();
                     done();
                 });
             });


### PR DESCRIPTION
As per http://docs.mongodb.org/manual/reference/method/db.collection.find/

A projection cannot contain both include and exclude specifications, except for the exclusion of the _id field. In projections that explicitly include fields, the _id field is the only field that you can explicitly exclude.