### PR TITLE
Fix utils#valuesAreObjectIds

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -96,10 +96,7 @@ function matchParams(item, query, q) {
 }
 
 function valuesAreObjectIds(item, value) {
-    if(item && value){
-        return _.isFunction(item.equals) && _.isFunction(value.equals);
-    }
-    return false;
+    return (item instanceof ObjectId && value instanceof ObjectId);
 }
 
 function matchValues(item, value) {


### PR DESCRIPTION
Currently `utils.valuesAreObjectIds` returns true, if you pass in a collection object as `item` and an ObjectId as `value`. The following call of `item.equals(value)` in the function `utils.matchValues` then raised an exception in one case in my code.

Using the proposed implementation of `utils.valuesAreObjectIds` the exception doesn't get raised and all Mockgoose tests still pass.