### PR TITLE
Allow ommiting `options` in Collection.remove call

### DIFF
--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -154,6 +154,11 @@ function Collection(mongoCollection, Model) {
     };
 
     this.remove = function (conditions, options, callback) {
+        if(typeof options === 'function') {
+          callback = options;
+          options = {};
+        }
+        options = options || {};
         this.find(conditions, options, function (err, results) {
             if (err) {
                 return callback(err);


### PR DESCRIPTION
Taken from here: https://github.com/mongodb/node-mongodb-native/blob/2.0/lib/collection.js#L719-L721