### PR TITLE
Fix logical $and and $or operations

### DIFF
--- a/lib/operations/logical/AndOperation.js
+++ b/lib/operations/logical/AndOperation.js
@@ -12,9 +12,9 @@ module.exports = function operation(model, update, options) {
         var valid = true;
         _.forIn(value, function (item, key) {
             if (operations.isOperation(item)) {
-                valid &= operations.getOperation(item)(model, value[key], {queryItem: key});
+                valid = valid && operations.getOperation(item)(model, value[key], {queryItem: key});
             } else {
-                valid &= _.isEqual(model[key], item);
+                valid = valid && _.isEqual(model[key], item);
             }
         });
         return valid;

--- a/lib/operations/logical/AndOperation.js
+++ b/lib/operations/logical/AndOperation.js
@@ -16,7 +16,11 @@ module.exports = function operation(model, update, options) {
             }else if (operations.isOperation(item)) {
                 valid = valid && operations.getOperation(item)(model, value[key], {queryItem: key});
             } else {
-                valid = valid && _.isEqual(model[key], item);
+                if (_.isArray(model[key])) {
+                    valid = valid && _.some(model[key], function(v) { return _.isEqual(v, item); });
+                } else {
+                    valid = valid && _.isEqual(model[key], item);
+                }
             }
         });
         return valid;

--- a/lib/operations/logical/AndOperation.js
+++ b/lib/operations/logical/AndOperation.js
@@ -10,8 +10,10 @@ var operations = require('./../Operations');
 module.exports = function operation(model, update, options) {
     var results = _.every(update.$and, function (value) {
         var valid = true;
-        _.forIn(value, function (item, key) {
-            if (operations.isOperation(item)) {
+        _.forIn(value, function (item, key, elem) {
+            if (operations.isOperation(elem)) {
+                valid = value && operations.getOperation(key)(model, elem, {queryItem: key});
+            }else if (operations.isOperation(item)) {
                 valid = valid && operations.getOperation(item)(model, value[key], {queryItem: key});
             } else {
                 valid = valid && _.isEqual(model[key], item);

--- a/lib/operations/logical/AndOperation.js
+++ b/lib/operations/logical/AndOperation.js
@@ -9,12 +9,12 @@ var operations = require('./../Operations');
  */
 module.exports = function operation(model, update, options) {
     var results = _.every(update.$and, function (value) {
-        var valid = false;
+        var valid = true;
         _.forIn(value, function (item, key) {
             if (operations.isOperation(item)) {
-                valid = operations.getOperation(item)(model, value[key], {queryItem: key});
+                valid &= operations.getOperation(item)(model, value[key], {queryItem: key});
             } else {
-                valid = _.isEqual(model[key], item);
+                valid &= _.isEqual(model[key], item);
             }
         });
         return valid;

--- a/lib/operations/logical/OrOperation.js
+++ b/lib/operations/logical/OrOperation.js
@@ -11,18 +11,18 @@ var utils = require('../../utils');
  */
 module.exports = function operation(model, update, options) {
     var results = _.find(update.$or, function (value) {
-        var valid = false;
+        var valid = true;
         _.forIn(value, function (item, key) {
             if (operations.isOperation(item)) {
-                valid = operations.getOperation(item)(model, value[key], {queryItem: key});
+                valid &= operations.getOperation(item)(model, value[key], {queryItem: key});
             }else if(utils.isNestedKey(key)){
-                valid = _.isEqual(utils.findNestedValue(model, key), item);
+                valid &= _.isEqual(utils.findNestedValue(model, key), item);
             }
             else {
                 if (_.isArray(model[key])) {
-                    valid = _.some(model[key], function(v) { return _.isEqual(v, item); });
+                    valid &= _.some(model[key], function(v) { return _.isEqual(v, item); });
                 } else {
-                    valid = _.isEqual(model[key], item);
+                    valid &= _.isEqual(model[key], item);
                 }
             }
         });

--- a/lib/operations/logical/OrOperation.js
+++ b/lib/operations/logical/OrOperation.js
@@ -12,8 +12,10 @@ var utils = require('../../utils');
 module.exports = function operation(model, update, options) {
     var results = _.find(update.$or, function (value) {
         var valid = true;
-        _.forIn(value, function (item, key) {
-            if (operations.isOperation(item)) {
+        _.forIn(value, function (item, key, elem) {
+            if (operations.isOperation(elem)) {
+                valid = valid && operations.getOperation(elem)(model, elem, {queryItem: key});
+            }else if (operations.isOperation(item)) {
                 valid = valid && operations.getOperation(item)(model, value[key], {queryItem: key});
             }else if(utils.isNestedKey(key)){
                 valid = valid && _.isEqual(utils.findNestedValue(model, key), item);

--- a/lib/operations/logical/OrOperation.js
+++ b/lib/operations/logical/OrOperation.js
@@ -14,15 +14,15 @@ module.exports = function operation(model, update, options) {
         var valid = true;
         _.forIn(value, function (item, key) {
             if (operations.isOperation(item)) {
-                valid &= operations.getOperation(item)(model, value[key], {queryItem: key});
+                valid = valid && operations.getOperation(item)(model, value[key], {queryItem: key});
             }else if(utils.isNestedKey(key)){
-                valid &= _.isEqual(utils.findNestedValue(model, key), item);
+                valid = valid && _.isEqual(utils.findNestedValue(model, key), item);
             }
             else {
                 if (_.isArray(model[key])) {
-                    valid &= _.some(model[key], function(v) { return _.isEqual(v, item); });
+                    valid = valid && _.some(model[key], function(v) { return _.isEqual(v, item); });
                 } else {
-                    valid &= _.isEqual(model[key], item);
+                    valid = valid && _.isEqual(model[key], item);
                 }
             }
         });

--- a/test/operations/logical/AndOperation.spec.js
+++ b/test/operations/logical/AndOperation.spec.js
@@ -99,6 +99,16 @@ describe('Mockgoose $and Tests', function () {
             });
         });
 
+        it('Find values that match $or inside $and operation', function (done) {
+            Model.find({ $and: [
+                { price: 1.99 },
+                { $or: [{qty: 19}, {sale: false}] }
+            ] }).exec().then(function (results) {
+                    expect(results.length).toBe(2);
+                    done();
+                });
+        });
+
         describe('Mongoose', function () {
 
             it('Find values with Mongoose and operation', function (done) {

--- a/test/operations/logical/AndOperation.spec.js
+++ b/test/operations/logical/AndOperation.spec.js
@@ -72,6 +72,16 @@ describe('Mockgoose $and Tests', function () {
             });
         });
 
+        it('Find values that match $and operation containing implicit and operations', function (done) {
+            Model.find({ $and: [
+                { price: 1.99, sale: true },
+                { qty: { $gt: 20 }, sale: true }
+            ] }).exec().then(function (results) {
+                    expect(results.length).toBe(2);
+                    done();
+                });
+        });
+
         it('Perform the $and operation on a single field', function (done) {
             Model.update({ $and: [
                 { price: { $ne: 1.99 } },

--- a/test/operations/logical/AndOperation.spec.js
+++ b/test/operations/logical/AndOperation.spec.js
@@ -10,7 +10,8 @@ describe('Mockgoose $and Tests', function () {
     var Schema = new mongoose.Schema({
         price: Number,
         qty: Number,
-        sale: Boolean
+        sale: Boolean,
+        historyprice: [Number]
     });
     var Model = mongoose.model('AllTests', Schema);
 
@@ -20,12 +21,14 @@ describe('Mockgoose $and Tests', function () {
             {
                 price: 1.99,
                 qty: 21,
-                sale: true
+                sale: true,
+                historyprice: [1.90, 1.77, 1.50]
             },
             {
                 price: 1.99,
                 qty: 21,
-                sale: true
+                sale: true,
+                historyprice: [20, 42]
             },
             {
                 price: 1.99,
@@ -107,6 +110,16 @@ describe('Mockgoose $and Tests', function () {
                     expect(results.length).toBe(2);
                     done();
                 });
+        });
+
+        it('$and in an array of values', function (done) {
+            Model.find({ $and: [
+                { historyprice: 1.90 },
+                { price: 1.99 }
+            ]}).exec().then(function(results) {
+                expect(results.length).toBe(1);
+                done();
+            });
         });
 
         describe('Mongoose', function () {

--- a/test/operations/logical/OrOperation.spec.js
+++ b/test/operations/logical/OrOperation.spec.js
@@ -121,8 +121,18 @@ describe('Mockgoose $or Tests', function () {
             });
         });
 
+        it('$or with array of implicit and-values', function (done) {
+          Model.find({ $or: [
+            { historyprice: 8.99, qty: 21 },
+            { price: 1.99, qty: 20 }
+          ]}).exec().then(function(results) {
+            expect(results.length).toBe(2);
+            done();
+          });
+        });
+
         it('$or in an array of values', function (done) {
-            Model.find({ $or: [ 
+            Model.find({ $or: [
                 { historyprice: 8.99 },
                 { price: 1.99 }
             ]}).exec().then(function(results) {

--- a/test/operations/logical/OrOperation.spec.js
+++ b/test/operations/logical/OrOperation.spec.js
@@ -140,5 +140,15 @@ describe('Mockgoose $or Tests', function () {
                 done();
             });
         });
+
+        it('Find values that match $and inside $or operation', function (done) {
+            Model.find({ $or: [
+                { $and: [{price: 1.99}, {qty: 20}] },
+                { $and: [{price: 10}, {qty: 21}] }
+            ] }).exec().then(function (results) {
+                    expect(results.length).toBe(2);
+                    done();
+                });
+        });
     });
 });


### PR DESCRIPTION
A search for

```
{ $or: [
         { historyprice: 8.99, qty: 21 },
         { price: 1.99, qty: 20 }
]}
```

does not work as expected. Instead of implicit `$and` operations, we have implicit `$or` operations in these cases. See e.g. the queries in the added unit tests. This PR fixes them.