### PR TITLE
Force errors via mocked Connection#readyState

### DIFF
--- a/Mockgoose.js
+++ b/Mockgoose.js
@@ -65,14 +65,17 @@ module.exports = function (mongoose, throwErrors) {
     };
 
     function handleConnection(callback, connection, err) {
+        setMockReadyState(connection, 2);
         connection.emit('connecting');
         if (callback) {
             //Always return true as we are faking it.
             callback(null, connection);
         }
         if (throwErrors) {
+            setMockReadyState(connection, 0);
             connection.emit('error', err);
         } else {
+            setMockReadyState(connection, 1);
             connection.emit('connected');
             connection.emit('open');
         }
@@ -113,6 +116,20 @@ module.exports = function (mongoose, throwErrors) {
         connection.model = mongoose.model;
         mongoose.connection.model = mongoose.model;
         return connection;
+    };
+
+    var setMockReadyState = module.exports.setMockReadyState = function(connection, state) {
+        /**
+         * mock version of Connection#readyState
+         * http://mongoosejs.com/docs/api.html#connection_Connection-readyState
+         *
+         * 0 = disconnected
+         * 1 = connected
+         * 2 = connecting
+         * 3 = disconnecting
+         *
+         */
+        connection._mockReadyState = mongoose.connection._mockReadyState = state;
     };
 
     module.exports.reset = function (type) {

--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -14,7 +14,7 @@ module.exports = Collection;
 function Collection(mongoCollection, Model) {
     var name = this.name = mongoCollection.name;
 //    var opts = this.opts = mongoCollection.opts;
-//    var conn = this.conn = mongoCollection.conn;
+    var conn = this.conn = mongoCollection.conn;
     /*jshint -W064 *///new operator.
     var schema = Model().schema;
     /*jshint -W106 *///Camel_Case
@@ -82,6 +82,9 @@ function Collection(mongoCollection, Model) {
     };
 
     this.find = function (conditions, options, callback) {
+        if (! conn._mockReadyState) {
+            return callback(new utils.ConnectionError());
+        }
         var results;
         var models = db[name];
         if (!_.isEmpty(conditions)) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,12 +18,20 @@ module.exports.isNestedKey = isNestedKey;
 module.exports.findNestedValue = findNestedValue;
 module.exports.setNestedValue = setNestedValue;
 module.exports.isRegExp = isRegExp;
+module.exports.ConnectionError = ConnectionError;
 
 //-------------------------------------------------------------------------
 //
 // Private Methods
 //
 //-------------------------------------------------------------------------
+
+function ConnectionError() {
+    var err = new Error('mock: connect failed');
+    err.name = 'MongoError';
+    err.code = 13328;
+    return err;
+}
 
 function findModelQuery(items, query) {
     return findMatch(items, query);

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "mongoose": "^3.8.9"
   },
   "devDependencies": {
-    "mongoose": "~3.8.2",
     "mongoose-validator": "~0.2.1",
     "bcrypt": "~0.7.5",
     "grunt": "~0.4.4",

--- a/test/Connection.spec.js
+++ b/test/Connection.spec.js
@@ -20,6 +20,7 @@ describe('Connection Tests', function () {
         it('Dispatch connecting event on connect', function (done) {
             var connection = mongoose.connect('mongodb://localhost:27017/blah').connection;
             connection.on('connecting', function () {
+                expect(connection._mockReadyState).toBe(2);
                 done();
             });
         });
@@ -27,6 +28,7 @@ describe('Connection Tests', function () {
         it('Dispatch connected event on connect', function (done) {
             var connection = mongoose.connect('mongodb://localhost:27017/blah').connection;
             connection.on('connected', function () {
+                expect(connection._mockReadyState).toBe(1);
                 done();
             });
         });
@@ -34,6 +36,7 @@ describe('Connection Tests', function () {
         it('Dispatch open event on connect', function (done) {
             var connection = mongoose.connect('mongodb://localhost:27017/blah').connection;
             connection.on('open', function () {
+                expect(connection._mockReadyState).toBe(1);
                 done();
             });
         });
@@ -44,6 +47,7 @@ describe('Connection Tests', function () {
             var connection = mongoose.connect('mongodb://localhost:27017/blah').connection;
             connection.on('error', function (err) {
                 expect(err).toBeDefined();
+                expect(connection._mockReadyState).toBe(0);
                 done();
             });
         });
@@ -51,6 +55,7 @@ describe('Connection Tests', function () {
         it('Dispatch connecting event on createConnection', function (done) {
             var connection = mongoose.createConnection('mongodb://localhost:27017/blah');
             connection.on('connecting', function () {
+                expect(connection._mockReadyState).toBe(2);
                 done();
             });
         });
@@ -58,6 +63,7 @@ describe('Connection Tests', function () {
         it('Dispatch connected event on createConnection', function (done) {
             var connection = mongoose.createConnection('mongodb://localhost:27017/blah');
             connection.on('connected', function () {
+                expect(connection._mockReadyState).toBe(1);
                 done();
             });
         });
@@ -65,6 +71,7 @@ describe('Connection Tests', function () {
         it('#68 https://github.com/mccormicka/Mockgoose/issues/68 Dispatch connected event once createConnection', function (done) {
             var connection = mongoose.createConnection('mongodb://localhost:27017/blah');
             connection.once('connected', function () {
+                expect(connection._mockReadyState).toBe(1);
                 done();
             });
         });
@@ -72,6 +79,7 @@ describe('Connection Tests', function () {
         it('Dispatch open event on createConnection', function (done) {
             var connection = mongoose.createConnection('mongodb://localhost:27017/blah');
             connection.on('open', function () {
+                expect(connection._mockReadyState).toBe(1);
                 done();
             });
         });
@@ -82,6 +90,7 @@ describe('Connection Tests', function () {
             var connection = mongoose.createConnection('mongodb://localhost:27017/blah');
             connection.on('error', function (err) {
                 expect(err).toBeDefined();
+                expect(connection._mockReadyState).toBe(0);
                 done();
             });
         });

--- a/test/Count.spec.js
+++ b/test/Count.spec.js
@@ -63,6 +63,17 @@ describe('Count Tests', function () {
             });
         });
 
+        it('Have an error when mongoose is disconnected', function (done) {
+            mockgoose.setMockReadyState(mongoose.connection, 0);
+
+            SimpleModel.count({}, function (err, count) {
+                expect(err).toBeDefined();
+                expect(count).toBeUndefined();
+                mockgoose.setMockReadyState(mongoose.connection, 1);
+                done();
+            });
+        });
+
         it('Model.count(function()) should NOT throw an error', function (done) {
             expect(function(){
                 SimpleModel.count(done);

--- a/test/Find.spec.js
+++ b/test/Find.spec.js
@@ -269,6 +269,17 @@ describe('Mockgoose Find Tests', function () {
             });
         });
 
+        it('Should have an error when mongoose is disconnected', function(done) {
+            mockgoose.setMockReadyState(mongoose.connection, 0);
+
+            SimpleModel.find({}, function (err, result) {
+                expect(err).toBeDefined();
+                expect(result).toBeUndefined();
+                mockgoose.setMockReadyState(mongoose.connection, 1);
+                done();
+            });
+        });
+
         it('Not be able to find an object by password', function (done) {
             AccountModel.find({password: 'password'}).exec().then(function (results) {
                 expect(results.length).toBe(0);
@@ -364,6 +375,18 @@ describe('Mockgoose Find Tests', function () {
                 if (result) {
                     expect(result.type).toBe('simple');
                 }
+                done();
+            });
+        });
+
+
+        it('Should have an error when mongoose is disconnected', function(done) {
+            mockgoose.setMockReadyState(mongoose.connection, 0);
+
+            SimpleModel.findOne({name: 'one', value: 'two'}, function (err, result) {
+                expect(err).toBeDefined();
+                expect(result).toBeUndefined();
+                mockgoose.setMockReadyState(mongoose.connection, 1);
                 done();
             });
         });

--- a/test/Remove.spec.js
+++ b/test/Remove.spec.js
@@ -51,6 +51,16 @@ describe('Mockgoose Remove Tests', function () {
             });
         });
 
+        it('Should have an error when mongoose is disconnected', function (done) {
+            mockgoose.setMockReadyState(mongoose.connection, 0);
+
+            SimpleModel.remove({name: 'one'}, function (err) {
+                expect(err).toBeDefined();
+                mockgoose.setMockReadyState(mongoose.connection, 1);
+                done();
+            });
+        });
+
         it('should be able to remove a model from a model object', function (done) {
             SimpleModel.find({name: 'one'}, function (err, result) {
                 expect(err).toBeFalsy();

--- a/test/Update.spec.js
+++ b/test/Update.spec.js
@@ -82,6 +82,25 @@ describe('Mockgoose Update Tests', function () {
 
             });
         });
+
+        it('Should have an error when mongoose is disconnected', function (done) {
+            AccountModel.create({email: 'testing@testing.com', password: 'password', values: ['one', 'two']}, function (err, model) {
+                expect(model).toBeDefined();
+                if (model) {
+                    mockgoose.setMockReadyState(mongoose.connection, 0);
+
+                    model.update({email: 'updated@testing.com'}, function (err, result) {
+                        expect(err).toBeDefined();
+                        expect(result).toBeUndefined();
+                        mockgoose.setMockReadyState(mongoose.connection, 1);
+                        done();
+                    });
+                } else {
+                    done(err);
+                }
+
+            });
+        });
     });
 
     describe('$pull', function () {

--- a/test/collection/Distinct.spec.js
+++ b/test/collection/Distinct.spec.js
@@ -47,6 +47,17 @@ describe('Mockgoose $distinct Tests', function () {
             });
         });
 
+        it('Should have error when mongoose is disconnected', function (done) {
+            mockgoose.setMockReadyState(mongoose.connection, 0);
+
+            Model.distinct('dist', function (err, values) {
+                expect(err).toBeDefined();
+                expect(values).toBeUndefined();
+                mockgoose.setMockReadyState(mongoose.connection, 1);
+                done();
+            });
+        });
+
         it('Return distinct nested items', function (done) {
             Model.distinct('item.sku').exec().then(function (values) {
                 values.sort();


### PR DESCRIPTION
One thing we've found in using mockgoose, is that it's hard to actually force `err` to be set in mongoose callbacks so that we can test error handling branches in our own code. This pull will allow you to set a mocked version of [Connection#readyState](http://mongoosejs.com/docs/api.html#connection_Connection-readyState) to force a connection error to be returned during query operations, like `find` or `count`.