### PR TITLE
Issue #106 - convert dot notation lookups into nested objects

### DIFF
--- a/lib/operations/UpdatePositionalOperator.js
+++ b/lib/operations/UpdatePositionalOperator.js
@@ -33,9 +33,10 @@ function isPositionalValueField(key) {
 }
 
 function createUpdateModelOptions(arrayKeys, condition, positionalArray, value) {
-    var conditionKey = findConditionKey(arrayKeys, condition);
-    var modelOriginalValue = condition[conditionKey];
-    var nestedPropertyKey = findNestedPropertyKey(conditionKey);
+    var conditionKeyAndValue = findConditionKeyAndValue(arrayKeys, condition);
+    var modelOriginalValue = conditionKeyAndValue.value;
+    var nestedPropertyKey = findNestedPropertyKey(conditionKeyAndValue.key);
+
     var options = {
         positionalArray: positionalArray,
         nestedPropertyKey: nestedPropertyKey,
@@ -65,6 +66,7 @@ function updatePositionalValue(model, condition, key, value) {
 function updatePositionalValueField(model, condition, key, value) {
     var arrayKeys = stripKeySeparators(key.split('$'));
     var positionalArray = model[arrayKeys[0]];
+
     if (!_.isUndefined(condition) && _.isArray(positionalArray)) {
         var options = createUpdateModelOptions(arrayKeys, condition, positionalArray, value);
         var length = positionalArray.length;
@@ -74,19 +76,49 @@ function updatePositionalValueField(model, condition, key, value) {
             }
         }
     }
+
     return false;
 }
 
-function findConditionKey(arrayKeys, condition) {
-    var conditionKey = arrayKeys[0];
-    _.forIn(condition, function (value, key) {
-        if (key.indexOf(arrayKeys[0]) > -1) {
-            conditionKey = key;
-            return false;
+function findConditionKeyAndValue(arrayKeys, condition) {
+    var conditionKey = arrayKeys[0],
+
+        /**
+         * Variable to hold the value of the deepest object
+         */
+        conditionValue,
+
+        /**
+         * Store a reference to the current value to dig through object
+         *
+         * @type {Object}
+         */
+        currentRef = condition[conditionKey],
+
+        /**
+         * Store a reference to the previous object that will be assigned later
+         * in the loop and updated if the new reference is not an object. This
+         * allows us to step back one.
+         *
+         * @type {Object}
+         */
+        previousRef = currentRef;
+
+    // traverse object and get deepest object and its value
+    while(_.isObject(currentRef)) {
+        var key = _.first(_.keys(currentRef));
+
+        currentRef = currentRef[key];
+
+        if(_.isObject(currentRef)) {
+            previousRef = currentRef;
+        } else {
+            conditionKey = previousRef;
+            conditionValue = currentRef;
         }
-        return true;
-    });
-    return conditionKey;
+    }
+
+    return {key: conditionKey, value: conditionValue};
 }
 
 function stripKeySeparators(keys) {
@@ -98,8 +130,12 @@ function stripKeySeparators(keys) {
 }
 
 function findNestedPropertyKey(conditionKey) {
-    var childPropertyArray = conditionKey.split('.');
-    return childPropertyArray[childPropertyArray.length - 1];
+    if(_.isString(conditionKey)) {
+        var childPropertyArray = conditionKey.split('.');
+        return childPropertyArray[childPropertyArray.length - 1];
+    } else {
+        return _.first(_.keys(conditionKey));
+    }
 }
 
 function updateModelValue(position, options) {
@@ -109,10 +145,13 @@ function updateModelValue(position, options) {
     var arrayKeys = options.arrayKeys;
     var value = options.value;
     var child = positionalArray[position];
+
     var childValue = child;
+
     if (_.isObject(child)) {
         childValue = child[nestedPropertyKey];
     }
+
     if (_.isEqual(modelOriginalValue, childValue)) {
         if (_.isObject(child)) {
             child[arrayKeys[arrayKeys.length - 1]] = value;

--- a/lib/operations/comparison/InOperation.js
+++ b/lib/operations/comparison/InOperation.js
@@ -18,8 +18,8 @@ module.exports = function  operation(model, update, options) {
         result = !!_.find(update.$in, function (value) {
             if (value instanceof ObjectId) {
                 value = value.toString();
-                modelValue = _.map(modelValue, function (x) { 
-                    return x instanceof ObjectId ? x.toString() : x; 
+                modelValue = _.map(modelValue, function (x) {
+                    return x instanceof ObjectId ? x.toString() : x;
                 });
             }
             return _.contains(modelValue, value);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -55,6 +55,13 @@ function buildResults(query, q, items, key, results) {
 }
 
 function foundModel(item, query, q) {
+    if(isNestedKey(q)) {
+        var tmpQueryValues = convertDotNotationKeyToObject(q, query[q]);
+
+        q = tmpQueryValues.q;
+        query = tmpQueryValues.query;
+    }
+
     if (matchParams(item, query, q)) {
         var allMatch = allParamsMatch(query, item);
         if (allMatch) {
@@ -78,20 +85,75 @@ function allParamsMatch(query, item) {
 }
 
 function matchItems(value, queryItem, query, q, item) {
-    var result = matchValues(value, queryItem);
+    var result = false;
+
+    // Identified condition where when the operation is "$ne", this method
+    // is returning true and causing the NEOperation module to never be
+    // invoked for check.
+    if(_.first(_.keys(query[q])) !== '$ne') {
+        result = matchValues(value, queryItem);
+    }
+
     if (!result) {
         result = matchObjectParams(query, q, item);
     }
+
     if (!result) {
         result = matchArrayParams(value, queryItem, query, q, item);
     }
+
     return result;
 }
 
 function matchParams(item, query, q) {
-    var value = findValue(q, item);
-    var queryItem = query[q];
+    // If query is an object, then build object path. findValue() does not have
+    // knowledge of the query so we must build object path from a nested object
+    // and handed it off to that method.
+    var objectPath = q,
+        queryItem = query[q],
+        objRef = query[q];
+
+    if(_.isObject(query) && !(objRef instanceof ObjectId)) {
+        var objPath = [q],
+            key;
+
+        // Loop through nested object to build an array of keys that will
+        // serve as the objectPath in the findValue() method.
+        //
+        // For example:
+        //
+        // { qty: { num: 4 }} -> ['qty', 'num']
+        //
+        // Notice -- This is the quivalent of 'qty.num'.split('.')
+        //
+        while(_.isObject(objRef) && !(objRef instanceof ObjectId)) {
+            key = _.first(_.keys(objRef));
+
+            objPath.push(key);
+            objRef = objRef[key];
+        }
+
+        // Only reassign the queryItem value to the last object reference
+        // if that reference is truthy and true
+        if(objRef) {
+            queryItem = objRef;
+        }
+
+        // Update the object path with array constructed by traversing nested
+        // object of keys.
+        //
+        // If the last key in the nested object is an operation i.e. $exists,
+        // don't reassign the objectPath as there are considerations for
+        // operations further down the processing change.
+        if(!operations.isOperation(key)) {
+            objectPath = objPath;
+        }
+    }
+
+    var value = findValue(objectPath, item);
+
     var result = matchItems(value, queryItem, query, q, item);
+
     return result;
 }
 
@@ -106,6 +168,7 @@ function matchValues(item, value) {
     if(valuesAreObjectIds(item, value)){
         return item.equals(value);
     }
+
     return _.isEqual(item, value);
 }
 
@@ -116,6 +179,7 @@ function resultObject(result, item) {
 function matchObjectParams(query, q, item) {
     var result = false;
     var queryValue = query[q];
+
     if (typeof queryValue === 'object') {
         if (isRegExp(query[q])) {
             result = operations.getOperation('$regex')(resultObject(result, item), {$regex: query[q]}, {query: query, queryItem: q});
@@ -126,6 +190,7 @@ function matchObjectParams(query, q, item) {
             result = nestedValuesMatch(result, queryValue, item, query, q);
         }
     }
+
     return result;
 }
 
@@ -191,11 +256,13 @@ function setNestedValue(model, objectPath, value) {
 }
 
 function findValue(objectPath, obj) {
-    var objPath = objectPath.split('.');
-    //Find our value.
+    // If objectPath is received as string, use split to conver it to an array
+    // otherwise, it should be an array.
+    var objPath = _.isString(objectPath) ? objectPath.split('.') : objectPath;
+
     var value = objectPath;
     for (var k = 0; k < objPath.length; k++) {
-        value = obj[objPath[k]];
+        value = obj !== null ? obj[objPath[k]] : null;
         obj = value;
         if (_.isUndefined(obj)) {
             break;
@@ -215,6 +282,7 @@ function findValue(objectPath, obj) {
             }
         }
     }
+
     return value;
 }
 
@@ -225,6 +293,66 @@ function findProperty(item, q) {
         value = value[prop];
     });
     return value;
+}
+
+/**
+ * If foundModel() receives a lookup path in dot notation, it will convert
+ * that to a nested object format.  This keeps operations after this point
+ * operating on a standard lookup format.
+ *
+ * Example:
+ *
+ * {"qty.sum": {$gte: 10}}
+ *
+ * becomes
+ *
+ * {qty: {sum: {$gte: 10}}}
+ *
+ * when called:
+ *
+ * convertDotNotationKeyToObject("qty.sum", {$gte: 10})
+ *
+ * @param  {String} key   Dot notation string to convert
+ * @param  {Mixed}  value Final value for assignment to deepest key
+ * @return {Object}       Values converted to nested object with new q and query values
+ */
+function convertDotNotationKeyToObject(key, value) {
+        /**
+         * Dot notation string converted to array
+         *
+         * @type {Array}
+         */
+    var values = key.split('.'),
+
+        /**
+         * Object to build
+         *
+         * @type {Object}
+         */
+        obj = {},
+
+        /**
+         * Store reference ot last created object for next iteration
+         */
+        lastObjRef;
+
+    for(var i = 0; i < values.length; i++) {
+        if(_.isEmpty(obj)) {
+            obj[values[i]] = lastObjRef = {};
+        } else if(i + 1 < values.length) {
+            lastObjRef[values[i]] = lastObjRef = {};
+        } else {
+            lastObjRef[values[i]] = value || {};
+        }
+    }
+
+    /**
+     * Throughout util lib, q is first key in object and query is the complete
+     * criteria for looking up a value in the item
+     *
+     * @type {Object}
+     */
+    return {q: _.first(values), query: obj};
 }
 
 function isRegExp(value) {
@@ -240,8 +368,25 @@ function nestedValuesMatch(result, queryValue, item, query, q) {
                 {query: query, queryItem: q}
             );
         } else if (operations.isOperation(query[q][key])) {
+            /**
+             * Initialize the item to hand off to the operation module with the
+             * plain item value.
+             *
+             * @type {Object}
+             */
+            var itemToEvaluate = item;
+
+            // If the item does not have the key value as a property and has
+            // the q as a property, itemToEvaluate becomes equal to the item's
+            // value at q.  This was added to fix issue where nested object that
+            // was only two levels deep was not properly being accessed.
+            if(!itemToEvaluate.hasOwnProperty(key) &&
+               itemToEvaluate.hasOwnProperty(q)) {
+                    itemToEvaluate = item[q];
+            }
+
             return operations.getOperation(query[q][key])(
-                resultObject(result, item),
+                resultObject(result, itemToEvaluate),
                 query[q][key],
                 {query: query, queryItem: key}
             );

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -56,7 +56,7 @@ function buildResults(query, q, items, key, results) {
 
 function foundModel(item, query, q) {
     if(isNestedKey(q)) {
-        var tmpQueryValues = convertDotNotationKeyToObject(q, query[q]);
+        var tmpQueryValues = convertDotNotationKeyToObject(q, query);
 
         q = tmpQueryValues.q;
         query = tmpQueryValues.query;
@@ -64,6 +64,7 @@ function foundModel(item, query, q) {
 
     if (matchParams(item, query, q)) {
         var allMatch = allParamsMatch(query, item);
+
         if (allMatch) {
             return item;//return cloneItem(item);
         }
@@ -313,16 +314,22 @@ function findProperty(item, q) {
  * convertDotNotationKeyToObject("qty.sum", {$gte: 10})
  *
  * @param  {String} key   Dot notation string to convert
- * @param  {Mixed}  value Final value for assignment to deepest key
+ * @param  {Object} query The original query value that will be merged with conversion result
  * @return {Object}       Values converted to nested object with new q and query values
  */
-function convertDotNotationKeyToObject(key, value) {
+function convertDotNotationKeyToObject(key, query) {
+        /**
+         * Final value for assignment to deepest key
+         * @type {Mixed}
+         */
+    var value = query[key],
+
         /**
          * Dot notation string converted to array
          *
          * @type {Array}
          */
-    var values = key.split('.'),
+        values = key.split('.'),
 
         /**
          * Object to build
@@ -345,6 +352,12 @@ function convertDotNotationKeyToObject(key, value) {
             lastObjRef[values[i]] = value || {};
         }
     }
+
+    // Retain query value by merging in original query
+    obj = _.merge(query, obj);
+
+    // Delete dot notation key that was converted to object
+    delete obj[key];
 
     /**
      * Throughout util lib, q is first key in object and query is the complete

--- a/test/operations/comparison/GreaterThanOperation.spec.js
+++ b/test/operations/comparison/GreaterThanOperation.spec.js
@@ -18,7 +18,10 @@ describe('Mockgoose $gt Tests', function () {
                 num: Number,
                 color: String
             }
-        ]
+        ],
+        summary: {
+            total: Number
+        }
     });
     var Model = mongoose.model('AllTests', Schema);
 
@@ -31,7 +34,10 @@ describe('Mockgoose $gt Tests', function () {
                     { size: 'S', num: 10, color: 'blue' },
                     { size: 'M', num: 45, color: 'blue' },
                     { size: 'L', num: 100, color: 'green' }
-                ]
+                ],
+                summary: {
+                    total: 155
+                }
             },
             {
                 code: 'abc',
@@ -40,7 +46,10 @@ describe('Mockgoose $gt Tests', function () {
                     { size: '6', num: 100, color: 'green' },
                     { size: '6', num: 50, color: 'blue' },
                     { size: '8', num: 100, color: 'brown' }
-                ]
+                ],
+                summary: {
+                    total: 250
+                }
             },
             {
                 code: 'efg',
@@ -49,14 +58,20 @@ describe('Mockgoose $gt Tests', function () {
                     { size: 'S', num: 10, color: 'blue' },
                     { size: 'M', num: 100, color: 'blue' },
                     { size: 'L', num: 100, color: 'green' }
-                ]
+                ],
+                summary: {
+                    total: 210
+                }
             },
             {
                 code: 'ijk',
                 tags: [ 'electronics', 'school' ],
                 qty: [
                     { size: 'M', num: 30, color: 'green' }
-                ]
+                ],
+                summary: {
+                    total: 30
+                }
             }, function (err) {
                 done(err);
             });
@@ -82,6 +97,86 @@ describe('Mockgoose $gt Tests', function () {
 
         it('Not match values $gt the value', function (done) {
             Model.find({ qty: { num: { $gt: 500 } }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(0);
+                    done();
+                }, done);
+        });
+
+        it('Be able to match dot notation values contained within list $gt', function (done) {
+            Model.find({
+                'qty.num': { $gt: 50 }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(3);
+                    done();
+                }, done);
+        });
+
+        it('Not match dot notation values contained within list $gt the value', function (done) {
+            Model.find({
+                'qty.num': { $gt: 500 }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(0);
+                    done();
+                }, done);
+        });
+
+        it('Be able to match dot notation values contained within list $gt', function (done) {
+            Model.find({
+                'summary.total': { $gt: 200 }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(2);
+                    done();
+                }, done);
+        });
+
+        it('Not match dot notation values contained within list $gt the value', function (done) {
+            Model.find({
+                'summary.total': { $gt: 500 }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(0);
+                    done();
+                }, done);
+        });
+
+        it('Be able to match nested values not in list $gt', function (done) {
+            Model.find({
+                summary: {total: { $gt: 200 } }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(2);
+                    done();
+                }, done);
+        });
+
+        it('Not match nested values not in list $gt the value', function (done) {
+            Model.find({
+                summary: {total: { $gt: 500 } }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(0);
+                    done();
+                }, done);
+        });
+
+        it('Be able to match dot notation nested values not in list $gt', function (done) {
+            Model.find({
+                'summary.total': { $gt: 200 }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(2);
+                    done();
+                }, done);
+        });
+
+        it('Not match dot notation nested values not in list $gt the value', function (done) {
+            Model.find({
+                'summary.total': { $gt: 500 }
             }).exec().then(function (results) {
                     expect(results).toBeDefined();
                     expect(results.length).toBe(0);

--- a/test/operations/comparison/GreaterThanOrEqualOperation.spec.js
+++ b/test/operations/comparison/GreaterThanOrEqualOperation.spec.js
@@ -173,6 +173,17 @@ describe('Mockgoose $gte Tests', function () {
                 }, done);
         });
 
+        it('Be able to match dot notation nested values not in list $gte with other criteria', function (done) {
+            Model.find({
+                'summary.total': { $gte: 155 },
+                code: 'abc'
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(1);
+                    done();
+                }, done);
+        });
+
         it('Not match dot notation nested values not in list $gte the value', function (done) {
             Model.find({
                 'summary.total': { $gte: 500 }

--- a/test/operations/comparison/GreaterThanOrEqualOperation.spec.js
+++ b/test/operations/comparison/GreaterThanOrEqualOperation.spec.js
@@ -18,7 +18,10 @@ describe('Mockgoose $gte Tests', function () {
                 num: Number,
                 color: String
             }
-        ]
+        ],
+        summary: {
+            total: Number
+        }
     });
     var Model = mongoose.model('AllTests', Schema);
 
@@ -31,7 +34,10 @@ describe('Mockgoose $gte Tests', function () {
                     { size: 'S', num: 10, color: 'blue' },
                     { size: 'M', num: 45, color: 'blue' },
                     { size: 'L', num: 100, color: 'green' }
-                ]
+                ],
+                summary: {
+                    total: 155
+                }
             },
             {
                 code: 'abc',
@@ -40,7 +46,10 @@ describe('Mockgoose $gte Tests', function () {
                     { size: '6', num: 100, color: 'green' },
                     { size: '6', num: 50, color: 'blue' },
                     { size: '8', num: 120, color: 'brown' }
-                ]
+                ],
+                summary: {
+                    total: 270
+                }
             },
             {
                 code: 'efg',
@@ -49,14 +58,20 @@ describe('Mockgoose $gte Tests', function () {
                     { size: 'S', num: 10, color: 'blue' },
                     { size: 'M', num: 100, color: 'blue' },
                     { size: 'L', num: 120, color: 'green' }
-                ]
+                ],
+                summary: {
+                    total: 230
+                }
             },
             {
                 code: 'ijk',
                 tags: [ 'electronics', 'school' ],
                 qty: [
                     { size: 'M', num: 30, color: 'green' }
-                ]
+                ],
+                summary: {
+                    total: 30
+                }
             }, function (err) {
                 done(err);
             });
@@ -69,7 +84,6 @@ describe('Mockgoose $gte Tests', function () {
     });
 
     describe('$gte Tests', function () {
-
         it('Be able to match values $gte', function (done) {
             Model.find({
                 qty: { num: { $gte: 120 } }
@@ -82,6 +96,86 @@ describe('Mockgoose $gte Tests', function () {
 
         it('Not match values $gte the value', function (done) {
             Model.find({ qty: { num: { $gte: 500 } }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(0);
+                    done();
+                }, done);
+        });
+
+        it('Be able to match dot notation values contained within list $gte', function (done) {
+            Model.find({
+                'qty.num': { $gte: 120 }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(2);
+                    done();
+                }, done);
+        });
+
+        it('Not match dot notation values contained within list $gte the value', function (done) {
+            Model.find({
+                'qty.num': { $gte: 500 }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(0);
+                    done();
+                }, done);
+        });
+
+        it('Be able to match dot notation values contained within list $gte', function (done) {
+            Model.find({
+                'summary.total': { $gte: 230 }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(2);
+                    done();
+                }, done);
+        });
+
+        it('Not match dot notation values contained within list $gte the value', function (done) {
+            Model.find({
+                'summary.total': { $gte: 500 }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(0);
+                    done();
+                }, done);
+        });
+
+        it('Be able to match nested values not in list $gte', function (done) {
+            Model.find({
+                summary: {total: { $gte: 155 } }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(3);
+                    done();
+                }, done);
+        });
+
+        it('Not match nested values not in list $gte the value', function (done) {
+            Model.find({
+                summary: {total: { $gte: 500 } }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(0);
+                    done();
+                }, done);
+        });
+
+        it('Be able to match dot notation nested values not in list $gte', function (done) {
+            Model.find({
+                'summary.total': { $gte: 155 }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(3);
+                    done();
+                }, done);
+        });
+
+        it('Not match dot notation nested values not in list $gte the value', function (done) {
+            Model.find({
+                'summary.total': { $gte: 500 }
             }).exec().then(function (results) {
                     expect(results).toBeDefined();
                     expect(results.length).toBe(0);

--- a/test/operations/comparison/LessThanOperation.spec.js
+++ b/test/operations/comparison/LessThanOperation.spec.js
@@ -18,7 +18,10 @@ describe('Mockgoose $lt Tests', function () {
                 num: Number,
                 color: String
             }
-        ]
+        ],
+        summary: {
+            total: Number
+        }
     });
     var Model = mongoose.model('AllTests', Schema);
 
@@ -31,7 +34,10 @@ describe('Mockgoose $lt Tests', function () {
                     { size: 'S', num: 10, color: 'blue' },
                     { size: 'M', num: 45, color: 'blue' },
                     { size: 'L', num: 100, color: 'green' }
-                ]
+                ],
+                summary: {
+                    total: 155
+                }
             },
             {
                 code: 'abc',
@@ -40,7 +46,10 @@ describe('Mockgoose $lt Tests', function () {
                     { size: '6', num: 100, color: 'green' },
                     { size: '6', num: 50, color: 'blue' },
                     { size: '8', num: 100, color: 'brown' }
-                ]
+                ],
+                summary: {
+                    total: 250
+                }
             },
             {
                 code: 'efg',
@@ -49,14 +58,20 @@ describe('Mockgoose $lt Tests', function () {
                     { size: 'S', num: 10, color: 'blue' },
                     { size: 'M', num: 100, color: 'blue' },
                     { size: 'L', num: 100, color: 'green' }
-                ]
+                ],
+                summary: {
+                    total: 210
+                }
             },
             {
                 code: 'ijk',
                 tags: [ 'electronics', 'school' ],
                 qty: [
                     { size: 'M', num: 30, color: 'green' }
-                ]
+                ],
+                summary: {
+                    total: 30
+                }
             }, function (err) {
                 done(err);
             });
@@ -82,6 +97,86 @@ describe('Mockgoose $lt Tests', function () {
 
         it('Not match values $lt the value', function (done) {
             Model.find({ qty: { num: { $lt: 10 } }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(0);
+                    done();
+                }, done);
+        });
+
+        it('Be able to match dot notation values contained within list $lt', function (done) {
+            Model.find({
+                'qty.num': { $lt: 30 }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(2);
+                    done();
+                }, done);
+        });
+
+        it('Not match dot notation values contained within list $lt the value', function (done) {
+            Model.find({
+                'qty.num': { $lt: 10 }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(0);
+                    done();
+                }, done);
+        });
+
+        it('Be able to match dot notation values contained within list $lt', function (done) {
+            Model.find({
+                'summary.total': { $lt: 210 }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(2);
+                    done();
+                }, done);
+        });
+
+        it('Not match dot notation values contained within list $lt the value', function (done) {
+            Model.find({
+                'summary.total': { $lt: 30 }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(0);
+                    done();
+                }, done);
+        });
+
+        it('Be able to match nested values not in list $lt', function (done) {
+            Model.find({
+                summary: {total: { $lt: 210 } }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(2);
+                    done();
+                }, done);
+        });
+
+        it('Not match nested values not in list $lt the value', function (done) {
+            Model.find({
+                summary: {total: { $lt: 30 } }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(0);
+                    done();
+                }, done);
+        });
+
+        it('Be able to match dot notation nested values not in list $lt', function (done) {
+            Model.find({
+                'summary.total': { $lt: 210 }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(2);
+                    done();
+                }, done);
+        });
+
+        it('Not match dot notation nested values not in list $lt the value', function (done) {
+            Model.find({
+                'summary.total': { $lt: 30 }
             }).exec().then(function (results) {
                     expect(results).toBeDefined();
                     expect(results.length).toBe(0);

--- a/test/operations/comparison/LessThanOrEqualOperation.spec.js
+++ b/test/operations/comparison/LessThanOrEqualOperation.spec.js
@@ -18,7 +18,10 @@ describe('Mockgoose $lte Tests', function () {
                 num: Number,
                 color: String
             }
-        ]
+        ],
+        summary: {
+            total: Number
+        }
     });
     var Model = mongoose.model('AllTests', Schema);
 
@@ -31,7 +34,10 @@ describe('Mockgoose $lte Tests', function () {
                     { size: 'S', num: 10, color: 'blue' },
                     { size: 'M', num: 45, color: 'blue' },
                     { size: 'L', num: 100, color: 'green' }
-                ]
+                ],
+                summary: {
+                    total: 155
+                }
             },
             {
                 code: 'abc',
@@ -40,7 +46,10 @@ describe('Mockgoose $lte Tests', function () {
                     { size: '6', num: 100, color: 'green' },
                     { size: '6', num: 50, color: 'blue' },
                     { size: '8', num: 100, color: 'brown' }
-                ]
+                ],
+                summary: {
+                    total: 250
+                }
             },
             {
                 code: 'efg',
@@ -49,14 +58,20 @@ describe('Mockgoose $lte Tests', function () {
                     { size: 'S', num: 10, color: 'blue' },
                     { size: 'M', num: 100, color: 'blue' },
                     { size: 'L', num: 100, color: 'green' }
-                ]
+                ],
+                summary: {
+                    total: 210
+                }
             },
             {
                 code: 'ijk',
                 tags: [ 'electronics', 'school' ],
                 qty: [
                     { size: 'M', num: 30, color: 'green' }
-                ]
+                ],
+                summary: {
+                    total: 30
+                }
             }, function (err) {
                 done(err);
             });
@@ -82,6 +97,86 @@ describe('Mockgoose $lte Tests', function () {
 
         it('Not match values $lte the value', function (done) {
             Model.find({ qty: { num: { $lte: 5 } }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(0);
+                    done();
+                }, done);
+        });
+
+        it('Be able to match dot notation values contained within list $lte', function (done) {
+            Model.find({
+                'qty.num': { $lte: 30 }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(3);
+                    done();
+                }, done);
+        });
+
+        it('Not match dot notation values contained within list $lte the value', function (done) {
+            Model.find({
+                'qty.num': { $lte: 5 }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(0);
+                    done();
+                }, done);
+        });
+
+        it('Be able to match dot notation values contained within list $lte', function (done) {
+            Model.find({
+                'summary.total': { $lte: 155 }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(2);
+                    done();
+                }, done);
+        });
+
+        it('Not match dot notation values contained within list $lte the value', function (done) {
+            Model.find({
+                'summary.total': { $lte: 5 }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(0);
+                    done();
+                }, done);
+        });
+
+        it('Be able to match nested values not in list $lte', function (done) {
+            Model.find({
+                summary: {total: { $lte: 155 } }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(2);
+                    done();
+                }, done);
+        });
+
+        it('Not match nested values not in list $lte the value', function (done) {
+            Model.find({
+                summary: {total: { $lte: 5 } }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(0);
+                    done();
+                }, done);
+        });
+
+        it('Be able to match dot notation nested values not in list $lte', function (done) {
+            Model.find({
+                'summary.total': { $lte: 155 }
+            }).exec().then(function (results) {
+                    expect(results).toBeDefined();
+                    expect(results.length).toBe(2);
+                    done();
+                }, done);
+        });
+
+        it('Not match dot notation nested values not in list $lte the value', function (done) {
+            Model.find({
+                'summary.total': { $lte: 5 }
             }).exec().then(function (results) {
                     expect(results).toBeDefined();
                     expect(results.length).toBe(0);


### PR DESCRIPTION
+ Utils lib now converts dot notation to a nested object format for subsequent code paths within that lib.
+ `matchParams()` in utils constructs an `objectPath` array if the query value is an object, this mimics the `.split('.')` functionality in `findValue()`.  Note, this `objectPath` construction must occurs in `matchParams()` because `findValue()` does not have knowledge of the query value.
+ Added comprehensive testing for $gt, $gte, $lt, $lte that check finds for both dot notation and nested objects.

I realize the changes within the core utils lib are somewhat extensive; however, it makes sense to convert the dot notation lookups early on in the code path and provide support for handling that notation throughout.  All of the tests are passing with these changes in effect.