### PR TITLE
Fix undefined options crash

### DIFF
--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -123,6 +123,7 @@ function Collection(mongoCollection, Model) {
     this.update = function (conditions, update, options, callback) {
         logOptions(options);
         conditions = conditions || {};
+        options = options || {};
         options.conditions = conditions;
         var self = this;
         this.find(conditions, options, function (err, results) {


### PR DESCRIPTION
If options passed to update are undefined, you'll just get a crash.