### PR TITLE
Use stable version of mongoose

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "bunyan": "~1.3.5",
     "lodash": "~3.6.0",
     "mongodb": "~2.0.27",
-    "mongoose": "^3.8.25",
+    "mongoose": "~3.8.25",
     "mongoosemask": "mccormicka/mongoosemask"
   },
   "devDependencies": {


### PR DESCRIPTION
Currently 3.x.x version is being used and it resolves to 3.9.7 that is unstable (due to non-standard versioning of mongoose). And that leads to 
```
##############################################################
#
#   !!! MONGOOSE WARNING !!!
#
#   This is an UNSTABLE release of Mongoose.
#   Unstable releases are available for preview/testing only.
#   DO NOT run this in production.
#
##############################################################
```
displayed every time I run tests.