### PR TITLE
Update Validation.js to better reflect Mongoose error

### DIFF
--- a/lib/validation/Validation.js
+++ b/lib/validation/Validation.js
@@ -39,5 +39,6 @@ function createError(indexName) {
     var error = new Error(errMessage, code);
     error.name = 'MongoError';
     error.code = code;
+    error.errmsg = errMessage;
     return error;
 }


### PR DESCRIPTION
Mongoose validation error when uniqueness is violated contains an 'errmsg' property. Added that to the mocked error object returned by createError()