### PR TITLE
Mongoose Peer Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "bunyan": "~1.3.5",
     "lodash": "~3.6.0",
     "mongodb": "~2.0.27",
-    "mongoose": "^3.8.25",
     "mongoosemask": "~0.0.6"
   },
   "devDependencies": {
@@ -46,8 +45,12 @@
     "grunt-contrib-watch": "0.6.1",
     "grunt-mocha-test": "0.12.7",
     "mocha": "~2.2.4",
+    "mongoose": "^3.8.25",
     "mongoose-validator": "~1.0.3",
     "node-uuid": "~1.4.3"
+  },
+  "peerDependencies" : {
+    "mongoose": "^3.8.25"
   },
   "bugs": {
     "url": "https://github.com/mccormicka/Mockgoose/issues"

--- a/test/Update.spec.js
+++ b/test/Update.spec.js
@@ -574,7 +574,7 @@ describe('Mockgoose Update Tests', function () {
                 done();
             });
 
-            it.only('should clone correctly model', function (done) {
+            it('should clone correctly model', function (done) {
                 Model.update({
                     name: 'foo'
                 }, {


### PR DESCRIPTION
Because of instanceof checks like the one added here:

https://github.com/mccormicka/Mockgoose/commit/9d9cd6898c5f545df979e63515e277e5f7607ace

schemas that have a type of `Schema.Types.ObjectId` that are manually added using `mongoose.Types.ObjectId();` get mangled by the _.clone() function and then dropped by the model init function. By switching to making mongoose be a peer dependency, it guarentees mockgoose is using the same mongoose instance that the main application uses.

This also removes the .only in the tests