### PR TITLE
Mongoose 4.x support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 before_install:
   - npm install -g npm
   - npm update -g npm

--- a/Mockgoose.js
+++ b/Mockgoose.js
@@ -56,6 +56,9 @@ module.exports = function (mongoose, throwErrors) {
             options = {};
         }
 
+        // Mongoose won't complain that a "blank" database doesn't exist.
+        database = '';
+
         logger.info('Creating Mockgoose database: CreateConnection', database, ' options: ', options);
         var connection = mongoose.originalCreateConnection.call(mongoose, database, options, function (err) {
             process.nextTick(function() {
@@ -116,8 +119,10 @@ module.exports = function (mongoose, throwErrors) {
         database = '';
 
         logger.info('Creating Mockgoose database: Connect ', database, ' options: ', options);
-        mongoose.originalConnect(database, options, function (err) {
-            handleConnection(callback, mongoose.connection, err);
+        mongoose.originalConnect.call(mongoose, database, options, function (err) {
+            process.nextTick(function() {
+                handleConnection(callback, mongoose.connection, err);
+            });
         });
         mongoose.connection.model = mongoose.model;
         return mongoose;

--- a/Mockgoose.js
+++ b/Mockgoose.js
@@ -112,6 +112,9 @@ module.exports = function (mongoose, throwErrors) {
             options = {};
         }
 
+        // Mongoose won't complain that a "blank" database doesn't exist.
+        database = '';
+
         logger.info('Creating Mockgoose database: Connect ', database, ' options: ', options);
         mongoose.originalConnect(database, options, function (err) {
             handleConnection(callback, mongoose.connection, err);

--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -135,7 +135,7 @@ function Collection(mongoCollection, Model) {
         var self = this;
         this.find(conditions, options, function (err, results) {
             if (err) {
-                return callback(err);
+                return callback(err, {result: {ok: 0, nModified: 0, n: 0}, connection: conn});
             }
             results.toArray(function (err, results) {
                 if (!results.length) {
@@ -149,12 +149,12 @@ function Collection(mongoCollection, Model) {
                         updateResult(insertModel, update, options);
                         self.insert(insertModel, options, function (err, result) {
                             if (err) {
-                                return callback(err);
+                                return callback(err, {result: {ok: 1, nModified: 0, n: 0}, connection: conn});
                             }
                             updateFoundItems(options, result, update, callback);
                         });
                     } else {
-                        callback(null, options.modify ? [] : 0);
+                        callback(null, options.modify ? [] : {result: {ok: 1, nModified: 0, n: 0}, connection: conn});
                     }
                 } else {
                     options.insert = false;
@@ -261,11 +261,11 @@ function Collection(mongoCollection, Model) {
             //Return original docs if new not specified.
             var originals = _.clone(results);
             updateResults(results, update, options);
-            callback(null, options.modify ? originals : originals.length);
+            callback(null, options.modify ? originals : {result: {ok: 1, n: originals.length}, connection: conn});
         } else {
             //Return modified items
             updateResults(results, update, options);
-            callback(null, options.modify ? results : results.length);
+            callback(null, options.modify ? results : {result: {ok: 1, n: results.length}, connection: conn});
         }
     }
 

--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -65,7 +65,12 @@ function Collection(mongoCollection, Model) {
         } else {
             options.modify = true;
             this.update(conditions, castedDoc, options, function (err, results) {
-                callback(err, results ? results[0] : null);
+                var result = null;
+                if (results && options['new']) {
+                    result = results[0];
+                    result.value = utils.cloneItem(result);
+                }
+                callback(err, result);
             });
         }
     };
@@ -175,6 +180,7 @@ function Collection(mongoCollection, Model) {
                     if (results.length) {
                         results = results[0];
                         delete db[name][results._id];
+                        results.value = utils.cloneItem(results);
                     } else {
                         results = null;
                     }

--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var logger = require('./Logger');
-var ObjectId = require('mongoose').Types.ObjectId;
+var ObjectId = require('./Types').ObjectId;
 var _ = require('lodash');
 
 var db = require('./db');

--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -33,6 +33,7 @@ function Collection(mongoCollection, Model) {
     //-------------------------------------------------------------------------
 
 
+    var self = this;
     this.ensureIndex = function (index, options, callback) {
         logger.info('Ensure Index Called with arguments', arguments);
         indexes[_.keys(index)[0] + '_1'] = _.pairs(index);
@@ -43,6 +44,12 @@ function Collection(mongoCollection, Model) {
     this.getIndexes = function (callback) {
         return callback(null, indexes);
     };
+
+    function ensureIndexes(indexes) {
+        for (var i = 0; i < indexes.length; i++) {
+            self.ensureIndex(indexes[i][0], indexes[i][1], function(){});
+        }
+    }
 
     this.mapReduce = function () {
         throw new Error('Collection#mapReduce unimplemented by mockgoose!');
@@ -281,4 +288,5 @@ function Collection(mongoCollection, Model) {
             getOperation(type)(result, update, options);
         });
     }
+    ensureIndexes(schema.indexes());
 }

--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -71,11 +71,22 @@ function Collection(mongoCollection, Model) {
             this.remove(conditions, options, callback);
         } else {
             options.modify = true;
+
+            var old;
+            if (!options['new']) {
+                this.findOne(conditions, options, function(err, result) {
+                    old = result;
+                })
+            }
             this.update(conditions, castedDoc, options, function (err, results) {
                 var result = null;
-                if (results && options['new']) {
+                if (results && results[0]) {
                     result = results[0];
-                    result.value = utils.cloneItem(result);
+                    if (options['new']) {
+                        result.value = utils.cloneItem(result);
+                    } else {
+                        result.value = utils.cloneItem(old);
+                    } 
                 }
                 callback(err, result);
             });

--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -76,7 +76,7 @@ function Collection(mongoCollection, Model) {
             if (!options['new']) {
                 this.findOne(conditions, options, function(err, result) {
                     old = result;
-                })
+                });
             }
             this.update(conditions, castedDoc, options, function (err, results) {
                 var result = null;

--- a/lib/Types.js
+++ b/lib/Types.js
@@ -1,0 +1,14 @@
+var path = require('path');
+
+var mongoose;
+try {
+    if (process.env.PWD.indexOf('node_modules') !== -1) {
+        mongoose = require(path.join(process.env.PWD, '..', 'mongoose'));
+    }
+} catch (e) {
+    console.warn('Using bundled mongoose version for ObjectId class: ' + require('mongoose/package.json').version);
+} finally {
+    mongoose = mongoose || require('mongoose');
+}
+
+module.exports = mongoose.Types;

--- a/lib/operations/AllOperation.js
+++ b/lib/operations/AllOperation.js
@@ -2,7 +2,7 @@
 
 var _ = require('lodash');
 var operations = require('./Operations');
-var ObjectId = require('mongoose').Types.ObjectId;
+var ObjectId = require('../Types').ObjectId;
 /**
  * Implementation of $all
  * @see http://docs.mongodb.org/manual/reference/operator/query/all/

--- a/lib/operations/comparison/InOperation.js
+++ b/lib/operations/comparison/InOperation.js
@@ -2,7 +2,7 @@
 
 var _ = require('lodash');
 var utils = require('../../utils');
-var ObjectId = require('mongoose').Types.ObjectId;
+var ObjectId = require('../../Types').ObjectId;
 
 /**
  * Implmentation of $in

--- a/lib/operations/comparison/NINOperation.js
+++ b/lib/operations/comparison/NINOperation.js
@@ -2,7 +2,7 @@
 
 var _ = require('lodash');
 var utils = require('../../utils');
-var ObjectId = require('mongoose').Types.ObjectId;
+var ObjectId = require('../../Types').ObjectId;
 /**
  * Implementation of $nin
  * @see http://docs.mongodb.org/manual/reference/operator/query/nin/

--- a/lib/options/Sort.js
+++ b/lib/options/Sort.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var _ = require('lodash');
-var ObjectId = require('mongoose').Types.ObjectId;
+var ObjectId = require('../Types').ObjectId;
 
 module.exports = function sortItems(sort, items) {
     var item = items[0];

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,6 @@
 'use strict';
 var _ = require('lodash');
-var ObjectId = require('mongoose').Types.ObjectId;
+var ObjectId = require('./Types').ObjectId;
 var operations = require('./operations/Operations');
 
 module.exports.isEmpty = _.isEmpty;
@@ -122,7 +122,10 @@ function matchObjectParams(query, q, item) {
     var result = false;
     var queryValue = query[q];
     if (typeof queryValue === 'object') {
-        if (isRegExp(query[q])) {
+        if (queryValue instanceof Date) {
+           result = item[q] instanceof Date && queryValue.getTime() === item[q].getTime();
+        }
+        else if (isRegExp(query[q])) {
             result = operations.getOperation('$regex')(resultObject(result, item), {$regex: query[q]}, {query: query, queryItem: q});
         }
         else if (operations.isOperation(q)) {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "in memory"
   ],
   "scripts": {
-    "test": "mocha --recursive test/ && grunt jshint"
+    "test": "mocha && grunt jshint"
   },
   "main": "Mockgoose",
   "files": [
@@ -32,7 +32,7 @@
   "dependencies": {
     "bunyan": "~1.3.5",
     "lodash": "~3.6.0",
-    "mongoose": "^3.8.25",
+    "mongoose": "~3.8.25",
     "mongoosemask": "~0.0.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "bunyan": "~1.3.5",
     "lodash": "~3.6.0",
-    "mongoose": "~3.8.25",
+    "mongoose": "^4.0.0",
     "mongoosemask": "~0.0.6"
   },
   "devDependencies": {

--- a/test/Connection.spec.js
+++ b/test/Connection.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 
 describe('Connection Tests', function () {
 
-    var mockgoose = require('../Mockgoose');
+    var mockgoose = require('..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose;
 

--- a/test/Count.spec.js
+++ b/test/Count.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 
 describe('Count Tests', function () {
 
-    var mockgoose = require('../Mockgoose');
+    var mockgoose = require('..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/Find.spec.js
+++ b/test/Find.spec.js
@@ -50,7 +50,6 @@ describe('Mockgoose Find Tests', function () {
     });
 
     describe('Find', function () {
-
         it('should be able to find an item by id', function (done) {
             AccountModel.create({email: 'one@one.com', password: 'password'},
                 {email: 'two@two.com', password: 'password'}, function (err, one, two) {
@@ -69,7 +68,8 @@ describe('Mockgoose Find Tests', function () {
                     } else {
                         done('Error creating items' + err + one + two);
                     }
-                });
+                }
+            );
         });
 
         it('should find all models if an empty {} object is passed to find', function (done) {
@@ -334,7 +334,6 @@ describe('Mockgoose Find Tests', function () {
     });
 
     describe('findOne', function () {
-
         it('should be able to findOne model by using a simple query', function (done) {
             AccountModel.findOne({email: 'valid@valid.com'}, function (err, model) {
                 expect(err).not.to.be.ok;
@@ -370,7 +369,6 @@ describe('Mockgoose Find Tests', function () {
                     }
                 });
             });
-
         });
 
         it('Be able to pass a fields includes string to findOne', function (done) {
@@ -408,9 +406,9 @@ describe('Mockgoose Find Tests', function () {
                         } else {
                             done('Unable to find' + err + result);
                         }
-
                     });
-                });
+                }
+            );
         });
 
         it('should match date values', function (done) {
@@ -446,10 +444,11 @@ describe('Mockgoose Find Tests', function () {
                         } else {
                             done('Unable to find' + err + result);
                         }
-
                     });
-                });
+                }
+            );
         });
+
         it('should find a models if an empty {} object is passed to findOne', function (done) {
             SimpleModel.findOne({}, function (err, result) {
                 expect(err).not.to.be.ok;
@@ -460,7 +459,6 @@ describe('Mockgoose Find Tests', function () {
                 done();
             });
         });
-
 
         it('Should have an error when mongoose is disconnected', function(done) {
             mockgoose.setMockReadyState(mongoose.connection, 0);
@@ -474,7 +472,6 @@ describe('Mockgoose Find Tests', function () {
         });
 
         describe('FindOne on nested document array', function () {
-
             var schema = new mongoose.Schema({ names: [] });
             var Model = mongoose.model('TestArrayQueries', schema);
 
@@ -501,7 +498,6 @@ describe('Mockgoose Find Tests', function () {
                 });
             });
         });
-
     });
 
     describe('findOneAndUpdate', function () {
@@ -509,24 +505,34 @@ describe('Mockgoose Find Tests', function () {
         it('should be able to findOneAndUpdate models', function (done) {
             AccountModel.create(
                 {email: 'multiples@valid.com', password: 'password', values: ['one', 'two']},
-                function () {
-                    AccountModel.findOneAndUpdate({email: 'multiples@valid.com'}, {email: 'updatedemail@email.com'}, function (err, result) {
-                        expect(result).to.not.be.undefined;
-                        if (result) {
-                            expect(result.email).to.equal('updatedemail@email.com');
-                            done(err);
-                        } else {
-                            done('Error finding models');
+                function() {
+                    AccountModel.findOneAndUpdate(
+                        {email: 'multiples@valid.com'},
+                        {email: 'updatedemail@email.com'},
+                        {'new': true}, // Tell Mongoose 4.x to return the new object.
+                        function (err, result) {
+                            expect(result).to.not.be.undefined;
+                            if (result) {
+                                expect(result.email).to.equal('updatedemail@email.com');
+                                done(err);
+                            } else {
+                                done('Error finding models');
+                            }
                         }
-                    });
-                });
+                    );
+                }
+            );
         });
 
         it('should be able to findOneAndUpdate models and saved model changed', function (done) {
             AccountModel.create(
                 {email: 'multiples@valid.com', password: 'password', values: ['one', 'two']},
                 function () {
-                    AccountModel.findOneAndUpdate({email: 'multiples@valid.com'}, {email: 'updatedemails@email.com'}, function (err, result) {
+                    AccountModel.findOneAndUpdate(
+                        {email: 'multiples@valid.com'},
+                        {email: 'updatedemails@email.com'},
+                        {'new': true}, // Tell Mongoose 4.x to return the new object.
+                        function (err, result) {
                         expect(result).to.not.be.undefined;
                         if (result) {
                             expect(result.email).to.equal('updatedemails@email.com');
@@ -536,15 +542,19 @@ describe('Mockgoose Find Tests', function () {
                             done(err);
                         });
                     });
-                });
+                }
+            );
         });
 
         it('should be able to findOneAndUpdate multiple values in models', function (done) {
             AccountModel.create(
                 {email: 'multiples@valid.com', password: 'password', values: ['one', 'two']},
                 function () {
-                    AccountModel.findOneAndUpdate({email: 'multiples@valid.com'},
-                        {email: 'updatedemail@email.com', values: ['updated']}, function (err, result) {
+                    AccountModel.findOneAndUpdate(
+                        {email: 'multiples@valid.com'},
+                        {email: 'updatedemail@email.com', values: ['updated']},
+                        {'new': true}, // Tell Mongoose 4.x to return the new object.
+                        function (err, result) {
                             expect(result).to.not.be.undefined;
                             if (result) {
                                 expect(result.email).to.equal('updatedemail@email.com');
@@ -553,12 +563,18 @@ describe('Mockgoose Find Tests', function () {
                             } else {
                                 done('Error finding models');
                             }
-                        });
-                });
+                        }
+                    );
+                }
+            );
         });
 
         it('should be able to findOneAndUpdate with an upsert', function (done) {
-            SimpleModel.findOneAndUpdate({name: 'upsert'}, {name: 'upsert'}, {upsert: true}, function (err, result) {
+            SimpleModel.findOneAndUpdate(
+                {name: 'upsert'},
+                {name: 'upsert'},
+                {upsert: true, 'new': true}, // Tell Mongoose 4.x to return the new object.
+                function (err, result) {
                 expect(err).not.to.be.ok;
                 expect(result).to.be.ok;
                 if (result) {
@@ -597,16 +613,22 @@ describe('Mockgoose Find Tests', function () {
                 {email: 'multiples@valid.com', password: 'password', values: ['one', 'two']},
                 function (err, result) {
                     var id = result._id;
-                    AccountModel.findByIdAndUpdate(id, {email: 'updatedemail@email.com'}, function (err, result) {
-                        expect(result).to.not.be.undefined;
-                        if (result) {
-                            expect(result.email).to.equal('updatedemail@email.com');
-                            done(err);
-                        } else {
-                            done('Error finding models');
+                    AccountModel.findByIdAndUpdate(
+                        id,
+                        {email: 'updatedemail@email.com'},
+                        {'new': true}, // Tell Mongoose 4.x to return the new object.
+                        function (err, result) {
+                            expect(result).to.not.be.undefined;
+                            if (result) {
+                                expect(result.email).to.equal('updatedemail@email.com');
+                                done(err);
+                            } else {
+                                done('Error finding models');
+                            }
                         }
-                    });
-                });
+                    );
+                }
+            );
         });
 
         it('should be able to findOneAndUpdate models and saved model changed', function (done) {
@@ -614,17 +636,23 @@ describe('Mockgoose Find Tests', function () {
                 {email: 'multiples@valid.com', password: 'password', values: ['one', 'two']},
                 function (err, result) {
                     var id = result._id;
-                    AccountModel.findByIdAndUpdate(id, {email: 'updatedemails@email.com'}, function (err, result) {
-                        expect(result).to.not.be.undefined;
-                        if (result) {
-                            expect(result.email).to.equal('updatedemails@email.com');
+                    AccountModel.findByIdAndUpdate(
+                        id,
+                        {email: 'updatedemails@email.com'},
+                        {'new': true}, // Tell Mongoose 4.x to return the new object.
+                        function (err, result) {
+                            expect(result).to.not.be.undefined;
+                            if (result) {
+                                expect(result.email).to.equal('updatedemails@email.com');
+                            }
+                            AccountModel.findOne({email: 'updatedemails@email.com'}, function (err, found) {
+                                expect(found).to.not.be.undefined;
+                                done(err);
+                            });
                         }
-                        AccountModel.findOne({email: 'updatedemails@email.com'}, function (err, found) {
-                            expect(found).to.not.be.undefined;
-                            done(err);
-                        });
-                    });
-                });
+                    );
+                }
+            );
         });
 
         it('should be able to findByIdAndUpdate multiple values in models', function (done) {
@@ -632,8 +660,11 @@ describe('Mockgoose Find Tests', function () {
                 {email: 'multiples@valid.com', password: 'password', values: ['one', 'two']},
                 function (err, result) {
                     var id = result._id;
-                    AccountModel.findByIdAndUpdate(id,
-                        {email: 'updatedemail@email.com', values: ['updated']}, function (err, result) {
+                    AccountModel.findByIdAndUpdate(
+                        id,
+                        {email: 'updatedemail@email.com', values: ['updated']},
+                        {'new': true}, // Tell Mongoose 4.x to return the new object.
+                        function (err, result) {
                             expect(result).to.not.be.undefined;
                             if (result) {
                                 expect(result.email).to.equal('updatedemail@email.com');
@@ -642,12 +673,18 @@ describe('Mockgoose Find Tests', function () {
                             } else {
                                 done('Error finding models');
                             }
-                        });
-                });
+                        }
+                    );
+                }
+            );
         });
 
         it('should be able to findByIdAndUpdate with an upsert', function (done) {
-            SimpleModel.findByIdAndUpdate('525ae43faa26361773000008', {name: 'upsert'}, {upsert: true}, function (err, result) {
+            SimpleModel.findByIdAndUpdate(
+                '525ae43faa26361773000008',
+                {name: 'upsert'},
+                {upsert: true, 'new': true}, // Tell Mongoose 4.x to return the new object.
+                function (err, result) {
                 expect(err).not.to.be.ok;
                 expect(result).to.be.ok;
                 if (result) {
@@ -688,7 +725,8 @@ describe('Mockgoose Find Tests', function () {
                             done('Error removing item!');
                         }
                     });
-                });
+                }
+            );
         });
 
         it('Not return an item if no item found to remove', function (done) {
@@ -718,7 +756,8 @@ describe('Mockgoose Find Tests', function () {
                             done('Error removing item!');
                         }
                     });
-                });
+                }
+            );
         });
 
         it('Not return an item if no item found to remove', function (done) {

--- a/test/Find.spec.js
+++ b/test/Find.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 describe('Mockgoose Find Tests', function () {
     'use strict';
 
-    var mockgoose = require('../Mockgoose');
+    var mockgoose = require('..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);
@@ -413,6 +413,43 @@ describe('Mockgoose Find Tests', function () {
                 });
         });
 
+        it('should match date values', function (done) {
+            SimpleModel.create(
+                {name: 'true', date: new Date('10-20-2014'), bool: true},
+                {name: 'false', date: '10-21-2014', bool: false}, function () {
+
+                    SimpleModel.findOne({date: new Date('10-20-2014')}, function (err, result) {
+                        if (result) {
+                            expect(result.name).to.equal('true');
+                            SimpleModel.findOne({date: '10-20-2014'}, function (err, result) {
+                                if (result) {
+                                    expect(result.name).to.equal('true');
+                                    SimpleModel.findOne({date: new Date('10-21-2014')}, function(err, result) {
+                                        if (result) {
+                                            expect(result.name).to.equal('false');
+                                            SimpleModel.findOne({date: '10-21-2014'}, function(err, result) {
+                                                if (result) {
+                                                    expect(result.name).to.equal('false');
+                                                    done(err);
+                                                } else {
+                                                    done('Unable to find' + err + result);
+                                                }
+                                            });
+                                        } else {
+                                            done('Unable to find' + err + result);
+                                        }
+                                    });
+                                } else {
+                                    done('Unable to find' + err + result);
+                                }
+                            });
+                        } else {
+                            done('Unable to find' + err + result);
+                        }
+
+                    });
+                });
+        });
         it('should find a models if an empty {} object is passed to findOne', function (done) {
             SimpleModel.findOne({}, function (err, result) {
                 expect(err).not.to.be.ok;

--- a/test/NestedReferences.spec.js
+++ b/test/NestedReferences.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 describe('Nested Ref Tests', function () {
     'use strict';
 
-    var mockgoose = require('../Mockgoose');
+    var mockgoose = require('..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/Populate.spec.js
+++ b/test/Populate.spec.js
@@ -6,7 +6,7 @@ describe('Mockgoose Populate test', function () {
     'use strict';
     var async = require('async');
 
-    var mockgoose = require('../Mockgoose');
+    var mockgoose = require('..');
     var Mongoose = require('mongoose');
 
     mockgoose(Mongoose);

--- a/test/Populate.spec.js
+++ b/test/Populate.spec.js
@@ -62,13 +62,15 @@ describe('Mockgoose Populate test', function () {
         it('should find the children objects within the parent', function (done) {
             CompanyEntry.findOne({name: 'Test Company'},function (err) {
                 expect(err).not.to.be.ok;
-
-            }).populate('users').exec(function (err, result) {
-                    expect(result.users.length).to.equal(1);
-                    var isInstanceOfUserEntry = result.users[0] instanceof UserEntry;
-                    expect(isInstanceOfUserEntry).to.be.true;
-                    done();
-                });
+            }).populate('users').exec(function (err, results) {
+                // Mongoose ignores the fact that this is a `findOne` and not a `find`
+                // after calling populate.
+                var result = results[0];
+                expect(result.users.length).to.equal(1);
+                var isInstanceOfUserEntry = result.users[0] instanceof UserEntry;
+                expect(isInstanceOfUserEntry).to.be.true;
+                done();
+            });
         });
 
         it('should not find children objects within the parent on subsequent non populate calls', function(done) {

--- a/test/Query.spec.js
+++ b/test/Query.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 describe('Mockgoose Query Tests', function () {
     'use strict';
 
-    var mockgoose = require('../Mockgoose');
+    var mockgoose = require('..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/Query.spec.js
+++ b/test/Query.spec.js
@@ -127,15 +127,20 @@ describe('Mockgoose Query Tests', function () {
                 {email: 'multiples@valid.com', password: 'password', values: ['one', 'two']},
                 function (err, result) {
                     var id = result._id;
-                    AccountModel.findByIdAndUpdate(id, {email: 'updatedemail@email.com'}).exec(function (err, result) {
-                        expect(result).not.to.be.undefined;
-                        if (result) {
-                            expect(result.email).to.equal('updatedemail@email.com');
-                            done(err);
-                        } else {
-                            done('Error finding models');
+                    AccountModel.findByIdAndUpdate(
+                        id,
+                        {email: 'updatedemail@email.com'},
+                        {'new': true}).
+                        exec(function (err, result) {
+                            expect(result).not.to.be.undefined;
+                            if (result) {
+                                expect(result.email).to.equal('updatedemail@email.com');
+                                done(err);
+                            } else {
+                                done('Error finding models');
+                            }
                         }
-                    });
+                    );
                 });
         });
     });
@@ -165,19 +170,23 @@ describe('Mockgoose Query Tests', function () {
         it('should be able to call exec ', function (done) {
             SimpleModel.create(
                 {name: 'unique', value: 'one'}, function (err, result) {
-                    SimpleModel.findOneAndRemove({name: 'unique'}).exec(function (err, removed) {
-                        expect(err).not.to.be.ok;
-                        if (removed) {
-                            expect(removed._id.toString()).to.equal(result._id.toString());
-                            SimpleModel.findOne({id: result._id}, function (err, item) {
-                                expect(item).to.be.null;
-                                done(err);
-                            });
+                    SimpleModel.findOneAndRemove(
+                        {name: 'unique'},
+                        {'new': true}).
+                        exec(function (err, removed) {
+                            expect(err).not.to.be.ok;
+                            if (removed) {
+                                expect(removed._id.toString()).to.equal(result._id.toString());
+                                SimpleModel.findOne({id: result._id}, function (err, item) {
+                                    expect(item).to.be.null;
+                                    done(err);
+                                });
+                            }
+                            else {
+                                done('Error removing item!');
+                            }
                         }
-                        else {
-                            done('Error removing item!');
-                        }
-                    });
+                    );
                 });
         });
 
@@ -193,7 +202,10 @@ describe('Mockgoose Query Tests', function () {
             AccountModel.create(
                 {email: 'multiples@valid.com', password: 'password', values: ['one', 'two']},
                 function () {
-                    AccountModel.findOneAndUpdate({email: 'multiples@valid.com'}, {email: 'updatedemail@email.com'})
+                    AccountModel.findOneAndUpdate(
+                        {email: 'multiples@valid.com'},
+                        {email: 'updatedemail@email.com'},
+                        {'new': true})
                         .exec(function (err, result) {
                             expect(result).not.to.be.undefined;
                             if (result) {

--- a/test/Remove.spec.js
+++ b/test/Remove.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 describe('Mockgoose Remove Tests', function () {
     'use strict';
 
-    var mockgoose = require('../Mockgoose');
+    var mockgoose = require('..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/Update.spec.js
+++ b/test/Update.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 describe('Mockgoose Update Tests', function () {
     'use strict';
 
-    var mockgoose = require('../Mockgoose');
+    var mockgoose = require('..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/Update.spec.js
+++ b/test/Update.spec.js
@@ -44,13 +44,12 @@ describe('Mockgoose Update Tests', function () {
     });
 
     describe('Update', function () {
-
         it('should be able to update items', function (done) {
             AccountModel.create({email: 'testing@testing.com', password: 'password', values: ['one', 'two']}, function (err, model) {
                 expect(model).not.to.be.undefined;
                 if (model) {
                     AccountModel.update({email: 'testing@testing.com'}, {email: 'updated@testing.com'}, function (err, result) {
-                        expect(result).to.equal(1);
+                        expect(result.n).to.equal(1);
                         AccountModel.findOne({email: 'updated@testing.com'}, function (err, result) {
                             if (result) {
                                 expect(result.email).to.equal('updated@testing.com');
@@ -71,7 +70,7 @@ describe('Mockgoose Update Tests', function () {
                 expect(model).not.to.be.undefined;
                 if (model) {
                     model.update({email: 'updated@testing.com'}, function (err, result) {
-                        expect(result).to.equal(1);
+                        expect(result.n).to.equal(1);
                         AccountModel.findOne({_id: model._id}, function (err, result) {
                             expect(result).not.to.be.undefined;
                             if (result) {
@@ -95,7 +94,7 @@ describe('Mockgoose Update Tests', function () {
 
                     model.update({email: 'updated@testing.com'}, function (err, result) {
                         expect(err).not.to.be.undefined;
-                        expect(result).to.be.undefined;
+                        expect(result.ok).to.equal(0);
                         mockgoose.setMockReadyState(mongoose.connection, 1);
                         done();
                     });
@@ -108,22 +107,26 @@ describe('Mockgoose Update Tests', function () {
     });
 
     describe('$pull', function () {
-
         it('should be able to pull items from nested documents array', function (done) {
             AccountModel.create(
                 {email: 'tester@valid.com', password: 'password', values: ['one', 'two']},
                 function () {
-                    AccountModel.findOneAndUpdate({email: 'tester@valid.com'}, {$pull: {values: 'one'}}, function (err, result) {
-                        expect(result).not.to.be.undefined;
-                        if (result) {
-                            expect(result.values.length).to.equal(1);
-                            expect(result.values[0]).to.equal('two');
-                            done(err);
-                        } else {
-                            done('Error finding item');
+                    AccountModel.findOneAndUpdate({email: 'tester@valid.com'},
+                        {$pull: {values: 'one'}},
+                        {'new': true},
+                        function (err, result) {
+                            expect(result).not.to.be.undefined;
+                            if (result) {
+                                expect(result.values.length).to.equal(1);
+                                expect(result.values[0]).to.equal('two');
+                                done(err);
+                            } else {
+                                done('Error finding item');
+                            }
                         }
-                    });
-                });
+                    );
+                }
+            );
         });
 
         it('should be able to pull items from nested documents array by property', function (done) {
@@ -133,21 +136,27 @@ describe('Mockgoose Update Tests', function () {
                     {name: 'two'}
                 ]},
                 function () {
-                    AccountModel.findOneAndUpdate({email: 'multiples@valid.com'}, {$pull: {values: {name: {$in: ['one']}}}}, function (err, result) {
-                        expect(result).not.to.be.undefined;
-                        if (result) {
-                            expect(result.values.length).to.equal(1);
-                            if (result.values.length === 1) {
-                                expect(result.values[0].name).to.equal('two');
-                                done(err);
+                    AccountModel.findOneAndUpdate(
+                        {email: 'multiples@valid.com'},
+                        {$pull: {values: {name: {$in: ['one']}}}},
+                        {'new': true},
+                        function (err, result) {
+                            expect(result).not.to.be.undefined;
+                            if (result) {
+                                expect(result.values.length).to.equal(1);
+                                if (result.values.length === 1) {
+                                    expect(result.values[0].name).to.equal('two');
+                                    done(err);
+                                } else {
+                                    done('Invalid value length', result.values);
+                                }
                             } else {
-                                done('Invalid value length', result.values);
+                                done('Error finding models');
                             }
-                        } else {
-                            done('Error finding models');
                         }
-                    });
-                });
+                    );
+                }
+            );
         });
 
         it('should be able to pull multiple items from nested documents array by property', function (done) {
@@ -158,21 +167,27 @@ describe('Mockgoose Update Tests', function () {
                     {name: 'three'}
                 ]},
                 function () {
-                    AccountModel.findOneAndUpdate({email: 'multiples@valid.com'}, {$pull: {values: {name: {$in: ['one', 'two']}}}}, function (err, result) {
-                        expect(result).not.to.be.undefined;
-                        if (result) {
-                            expect(result.values.length).to.equal(1);
-                            if (result.values.length === 1) {
-                                expect(result.values[0].name).to.equal('three');
-                                done(err);
+                    AccountModel.findOneAndUpdate(
+                        {email: 'multiples@valid.com'},
+                        {$pull: {values: {name: {$in: ['one', 'two']}}}},
+                        {'new': true},
+                        function (err, result) {
+                            expect(result).not.to.be.undefined;
+                            if (result) {
+                                expect(result.values.length).to.equal(1);
+                                if (result.values.length === 1) {
+                                    expect(result.values[0].name).to.equal('three');
+                                    done(err);
+                                } else {
+                                    done('invalid values length');
+                                }
                             } else {
-                                done('invalid values length');
+                                done('Error finding models');
                             }
-                        } else {
-                            done('Error finding models');
                         }
-                    });
-                });
+                    );
+                }
+            );
         });
     });
 
@@ -190,7 +205,7 @@ describe('Mockgoose Update Tests', function () {
                     if (result) {
                         AccountModel.update({email: 'pushed@pushed.com'}, {$push: {values: {name: 'pushed'}}}, function (err, result) {
                             expect(err).not.to.be.ok;
-                            expect(result).to.equal(1);
+                            expect(result.n).to.equal(1);
                             if (result) {
                                 AccountModel.findOne({email: 'pushed@pushed.com'}, function (err, pushed) {
                                     expect(err).not.to.be.ok;
@@ -223,7 +238,7 @@ describe('Mockgoose Update Tests', function () {
                     if (result) {
                         result.update({$push: {values: {name: 'pushed'}}}, function (err, result) {
                             expect(err).not.to.be.ok;
-                            expect(result).to.equal(1);
+                            expect(result.n).to.equal(1);
                             if (result) {
                                 AccountModel.findOne({email: 'pushed@pushed.com'}, function (err, pushed) {
                                     expect(err).not.to.be.ok;
@@ -260,7 +275,7 @@ describe('Mockgoose Update Tests', function () {
                             {name: 'pushed2'}
                         ]}}}, function (err, result) {
                             expect(err).not.to.be.ok;
-                            expect(result).to.equal(1);
+                            expect(result.n).to.equal(1);
                             if (result) {
                                 AccountModel.findOne({email: 'pushed@pushed.com'}, function (err, pushed) {
                                     expect(err).not.to.be.ok;
@@ -290,7 +305,7 @@ describe('Mockgoose Update Tests', function () {
                     if (result) {
                         AccountModel.update({}, {$push: {values: 'pushed'}}, {multi: 0, sort:{email:1}}, function (err, result) {
                             expect(err).not.to.be.ok;
-                            expect(result).to.equal(1);
+                            expect(result.n).to.equal(1);
                             if (result) {
                                 AccountModel.find({values: {$in: ['pushed']}}, function (err, pushed) {
                                     expect(err).not.to.be.ok;
@@ -320,7 +335,7 @@ describe('Mockgoose Update Tests', function () {
                     if (result) {
                         AccountModel.update({}, {$push: {values: 'pushed'}}, {multi: 1}, function (err, result) {
                             expect(err).not.to.be.ok;
-                            expect(result).to.equal(3);
+                            expect(result.n).to.equal(3);
                             if (result) {
                                 AccountModel.find({values: {$in: ['pushed']}}, function (err, pushed) {
                                     expect(err).not.to.be.ok;
@@ -351,25 +366,30 @@ describe('Mockgoose Update Tests', function () {
     describe('upsert', function () {
 
         it('should be able to findOneAndUpdate with an upsert', function (done) {
-            SimpleModel.findOneAndUpdate({name: 'upsert'}, {name: 'upsert'}, {upsert: true}, function (err, result) {
-                expect(err).not.to.be.ok;
-                expect(result).to.be.ok;
-                if (result) {
-                    expect(result.name).to.equal('upsert');
-                    SimpleModel.findOne({name: 'upsert'}, function (err, result) {
-                        expect(err).not.to.be.ok;
-                        expect(result).to.be.ok;
-                        if (result) {
-                            expect(result.name).to.equal('upsert');
-                            done(err);
-                        } else {
-                            done('Unable to find ' + err + result);
-                        }
-                    });
-                } else {
-                    done(err);
+            SimpleModel.findOneAndUpdate(
+                {name: 'upsert'},
+                {name: 'upsert'},
+                {upsert: true, 'new': true},
+                function (err, result) {
+                    expect(err).not.to.be.ok;
+                    expect(result).to.be.ok;
+                    if (result) {
+                        expect(result.name).to.equal('upsert');
+                        SimpleModel.findOne({name: 'upsert'}, function (err, result) {
+                            expect(err).not.to.be.ok;
+                            expect(result).to.be.ok;
+                            if (result) {
+                                expect(result.name).to.equal('upsert');
+                                done(err);
+                            } else {
+                                done('Unable to find ' + err + result);
+                            }
+                        });
+                    } else {
+                        done(err);
+                    }
                 }
-            });
+            );
         });
 
         it('should not be able to findOneAndUpdate without an upsert', function (done) {
@@ -404,11 +424,16 @@ describe('Mockgoose Update Tests', function () {
             });
 
             it('Update nested value', function (done) {
-                Model.findOneAndUpdate({'access_token.key' : 'token'}, {'access_token.expiration' : null}).exec().then(function(data){
-                    expect(data._doc['access_token.expiration']).to.equal(undefined);
-                    expect(data.access_token.expiration).to.equal(null);
-                    done();
-                });
+                Model.findOneAndUpdate(
+                    {'access_token.key' : 'token'},
+                    {'access_token.expiration' : null},
+                    {'new': true}).
+                    exec().then(function(data) {
+                        expect(data._doc['access_token.expiration']).to.equal(undefined);
+                        expect(data.access_token.expiration).to.equal(null);
+                        done();
+                    }
+                );
             });
 
         });
@@ -521,11 +546,16 @@ describe('Mockgoose Update Tests', function () {
             });
 
             it('pass conditions to upsert', function (done) {
-                Model.findOneAndUpdate({name:'updateName'}, {age:35}, {upsert:true}).exec().then(function(model){
-                    expect(model.name).to.equal('updateName');
-                    expect(model.age).to.equal(35);
-                    done();
-                });
+                Model.findOneAndUpdate(
+                    {name:'updateName'},
+                    {age:35},
+                    {upsert:true, 'new': true}).
+                    exec().then(function(model){
+                        expect(model.name).to.equal('updateName');
+                        expect(model.age).to.equal(35);
+                        done();
+                    }
+                );
             });
         });
 
@@ -546,16 +576,21 @@ describe('Mockgoose Update Tests', function () {
             });
 
             it('should generate duplicate key error on upsert', function (done) {
-                Model.findOneAndUpdate({name:'name1'}, {title:'unique'}, {upsert:true}, function (err, model) {
-                    expect(model.name).to.equal('name1');
-                    expect(model.title).to.equal('unique');
+                Model.findOneAndUpdate(
+                    {name:'name1'},
+                    {title:'unique'},
+                    {upsert:true, 'new': true},
+                    function (err, model) {
+                        expect(model.name).to.equal('name1');
+                        expect(model.title).to.equal('unique');
 
-                    Model.findOneAndUpdate({name:'name2'}, {title:'unique'}, {upsert:true}, function (err, model) {
-                        expect(err).not.to.be.undefined;
-                        expect(model).to.be.undefined;
-                        done();
-                    });
-                });
+                        Model.findOneAndUpdate({name:'name2'}, {title:'unique'}, {upsert:true}, function (err, model) {
+                            expect(err).not.to.be.undefined;
+                            expect(model).to.be.undefined;
+                            done();
+                        });
+                    }
+                );
             });
         });
 
@@ -583,7 +618,7 @@ describe('Mockgoose Update Tests', function () {
                     upsert: true
                 }, function(err, update) {
                     expect(err).not.to.be.undefined;
-                    expect(update).to.eql(1);
+                    expect(update.n).to.eql(1);
 
                     Model.count(function(err, count) {
                         expect(err).not.to.be.undefined;
@@ -595,7 +630,7 @@ describe('Mockgoose Update Tests', function () {
                             name: 'bar'
                         }, function(err, update) {
                             expect(err).not.to.be.undefined;
-                            expect(update).to.eql(1);
+                            expect(update.n).to.eql(1);
 
                             Model.count(function(err, count) {
                                 expect(err).not.to.be.undefined;

--- a/test/Validation.spec.js
+++ b/test/Validation.spec.js
@@ -6,7 +6,7 @@ var async  = require('async');
 describe('Mockgoose model validation Tests', function () {
     'use strict';
 
-    var mockgoose = require('../Mockgoose');
+    var mockgoose = require('..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/collection/Distinct.spec.js
+++ b/test/collection/Distinct.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 describe('Mockgoose $distinct Tests', function () {
     'use strict';
 
-    var mockgoose = require('./../../Mockgoose');
+    var mockgoose = require('../..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -6,7 +6,7 @@ var expect = require('chai').expect;
 describe('Index Tests', function () {
     'use strict';
 
-    var mockgoose = require('../Mockgoose');
+    var mockgoose = require('..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);
@@ -42,8 +42,8 @@ describe('Index Tests', function () {
 
             it('Be able to retrieve indexes from a model', function (done) {
                 collection.getIndexes(function(err, indexes){
-                    //expect(indexes).to.deep.equal({ _id_ : [ [ '_id', 1 ] ], expire_1 : [ [ 'expire', 1 ] ] });
-                    expect(indexes).to.deep.equal({ _id_ : [ [ '_id', 1 ] ] });
+                    expect(indexes).to.deep.equal({ _id_ : [ [ '_id', 1 ] ], expire_1 : [ [ 'expire', 1 ] ] });
+                    // expect(indexes).to.deep.equal({ _id_ : [ [ '_id', 1 ] ] }); wtf?
                     done();
                 });
             });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -2,13 +2,15 @@
 /*jshint -W106 *///Camel_Case
 /*jshint -W079 */ //redefined expect
 var expect = require('chai').expect;
+var mockgoose = require('..');
+var Mongoose = require('mongoose').Mongoose;
+var mongoose = new Mongoose();
+var Schema = mongoose.Schema;
 
 describe('Index Tests', function () {
     'use strict';
 
-    var mockgoose = require('..');
-    var Mongoose = require('mongoose').Mongoose;
-    var mongoose = new Mongoose();
+
     mockgoose(mongoose);
     var db = mongoose.connect('mongodb://localhost:27017/TestingDB');
 
@@ -22,13 +24,13 @@ describe('Index Tests', function () {
     describe('SHOULD', function () {
 
         describe('Setup Indexes', function () {
-            var indexSchema = {
+            var indexSchema = new Schema({
                 expire: {
                     type: Date,
                     expires: 1000,
                     'default': Date.now
                 }
-            };
+            });
             var IndexModel = db.model('indexmodel', indexSchema);
 
             beforeEach(function(done){
@@ -43,7 +45,6 @@ describe('Index Tests', function () {
             it('Be able to retrieve indexes from a model', function (done) {
                 collection.getIndexes(function(err, indexes){
                     expect(indexes).to.deep.equal({ _id_ : [ [ '_id', 1 ] ], expire_1 : [ [ 'expire', 1 ] ] });
-                    // expect(indexes).to.deep.equal({ _id_ : [ [ '_id', 1 ] ] }); wtf?
                     done();
                 });
             });

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,2 @@
+--recursive
+--no-exit

--- a/test/mockgoose.spec.js
+++ b/test/mockgoose.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 describe('Mockgoose Tests', function () {
     'use strict';
 
-    var mockgoose = require('../Mockgoose');
+    var mockgoose = require('..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/models/AccountModel.js
+++ b/test/models/AccountModel.js
@@ -27,7 +27,7 @@ module.exports = function (mongoose) {
             validate: [validate({message: 'min.length:6', validator: 'isLength', arguments: [6], passIfEmpty: true})]
         },
         values:[]
-    });
+    }, {strict: false});
 
     /**
      * Expose type to outside world.

--- a/test/operations/AddToSetOperation.spec.js
+++ b/test/operations/AddToSetOperation.spec.js
@@ -31,24 +31,39 @@ describe('Mockgoose $addToSet Tests', function () {
     describe('$addToSet', function () {
 
         it('Be able to a value to the set', function (done) {
-            AccountModel.findOneAndUpdate({email: 'valid@valid.com'}, {$addToSet: {values: 3}}, function (err, res) {
-                expect(res.values.toString()).to.equal([1,2,3].toString());
-                done(err);
-            });
+            AccountModel.findOneAndUpdate(
+                {email: 'valid@valid.com'},
+                {$addToSet: {values: 3}},
+                {'new': true},
+                function (err, res) {
+                    expect(res.values.toString()).to.equal([1,2,3].toString());
+                    done(err);
+                }
+            );
         });
 
         it('NOT Be able to add a DUPLICATE value to the set', function (done) {
-            AccountModel.findOneAndUpdate({email: 'valid@valid.com'}, {$addToSet: {values: 2}}, function (err, res) {
-                expect(res.values.toString()).to.equal([1,2].toString());
-                done(err);
-            });
+            AccountModel.findOneAndUpdate(
+                {email: 'valid@valid.com'},
+                {$addToSet: {values: 2}},
+                {'new': true},
+                function (err, res) {
+                    expect(res.values.toString()).to.equal([1,2].toString());
+                    done(err);
+                }
+            );
         });
 
         it('$each NOT add items from array that are DUPLICATE ', function (done) {
-            AccountModel.findOneAndUpdate({email: 'valid@valid.com'}, {$addToSet: {values: {$each:[1,2,3,4,5]}}}, function (err, res) {
-                expect(res.values.toString()).to.equal([1,2, 3, 4, 5].toString());
-                done(err);
-            });
+            AccountModel.findOneAndUpdate(
+                {email: 'valid@valid.com'},
+                {$addToSet: {values: {$each:[1,2,3,4,5]}}},
+                {'new': true},
+                function (err, res) {
+                    expect(res.values.toString()).to.equal([1,2, 3, 4, 5].toString());
+                    done(err);
+                }
+            );
         });
     });
 });

--- a/test/operations/AddToSetOperation.spec.js
+++ b/test/operations/AddToSetOperation.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 describe('Mockgoose $addToSet Tests', function () {
     'use strict';
 
-    var mockgoose = require('./../../Mockgoose');
+    var mockgoose = require('../..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/operations/AllOperation.spec.js
+++ b/test/operations/AllOperation.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 describe('Mockgoose $all Tests', function () {
     'use strict';
 
-    var mockgoose = require('./../../Mockgoose');
+    var mockgoose = require('../..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/operations/ElemMatchOperation.spec.js
+++ b/test/operations/ElemMatchOperation.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 describe('Mockgoose $elemMatch Tests', function () {
     'use strict';
 
-    var mockgoose = require('./../../Mockgoose');
+    var mockgoose = require('../..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/operations/ExistsOperation.spec.js
+++ b/test/operations/ExistsOperation.spec.js
@@ -2,7 +2,7 @@
 /*jshint -W079 */ //redefined expect
  'use strict';
 var expect = require('chai').expect;
-var mockgoose = require('./../../Mockgoose');
+var mockgoose = require('../..');
 var Mongoose = require('mongoose').Mongoose;
 var mongoose = new Mongoose();
 mockgoose(mongoose);

--- a/test/operations/IncOperation.spec.js
+++ b/test/operations/IncOperation.spec.js
@@ -33,25 +33,40 @@ describe('Mockgoose $INC Operation Tests', function () {
     describe('$inc', function () {
 
         it('Be able to increment a value', function (done) {
-            IndexModel.findOneAndUpdate({name: 'one'}, {$inc: {value: 5}}, function (err, res) {
-                expect(res.value).to.equal(8);
-                done(err);
-            });
+            IndexModel.findOneAndUpdate(
+                {name: 'one'},
+                {$inc: {value: 5}},
+                {'new': true},
+                function (err, res) {
+                    expect(res.value).to.equal(8);
+                    done(err);
+                }
+            );
         });
 
         it('Be able to decrement a value', function (done) {
-            IndexModel.findOneAndUpdate({name: 'one'}, {$inc: {value: -5}}, function (err, res) {
-                expect(res.value).to.equal(-2);
-                done(err);
-            });
+            IndexModel.findOneAndUpdate(
+                {name: 'one'},
+                {$inc: {value: -5}},
+                {'new': true},
+                function (err, res) {
+                    expect(res.value).to.equal(-2);
+                    done(err);
+                }
+            );
         });
 
         it('Be able to update multiple values', function (done) {
-            IndexModel.findOneAndUpdate({name: 'one'}, {$inc: {value: -5, increment: 5}}, function (err, res) {
-                expect(res.value).to.equal(-2);
-                expect(res.increment).to.equal(10);
-                done(err);
-            });
+            IndexModel.findOneAndUpdate(
+                {name: 'one'},
+                {$inc: {value: -5, increment: 5}},
+                {'new': true},
+                function (err, res) {
+                    expect(res.value).to.equal(-2);
+                    expect(res.increment).to.equal(10);
+                    done(err);
+                }
+            );
         });
 
     });

--- a/test/operations/IncOperation.spec.js
+++ b/test/operations/IncOperation.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 describe('Mockgoose $INC Operation Tests', function () {
     'use strict';
 
-    var mockgoose = require('../../Mockgoose');
+    var mockgoose = require('../..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/operations/PositionalOperation.spec.js
+++ b/test/operations/PositionalOperation.spec.js
@@ -6,7 +6,7 @@ describe('Mockgoose $ positional Tests', function () {
     'use strict';
 
     var _ = require('lodash');
-    var mockgoose = require('./../../Mockgoose');
+    var mockgoose = require('../..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/operations/PullAllOperation.spec.js
+++ b/test/operations/PullAllOperation.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 describe('Mockgoose Update Tests', function () {
     'use strict';
 
-    var mockgoose = require('../../../Mockgoose');
+    var mockgoose = require('../../');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/operations/PullAllOperation.spec.js
+++ b/test/operations/PullAllOperation.spec.js
@@ -37,16 +37,21 @@ describe('Mockgoose Update Tests', function () {
             AccountModel.create(
                 {email: 'tester@valid.com', password: 'password', values: ['one', 'two']},
                 function () {
-                    AccountModel.findOneAndUpdate({email: 'tester@valid.com'}, {$pullAll: {values: ['one']}}, function (err, result) {
-                        expect(result).not.to.be.undefined;
-                        if (result) {
-                            expect(result.values.length).to.equal(1);
-                            expect(result.values[0]).to.equal('two');
-                            done(err);
-                        } else {
-                            done('Error finding item');
+                    AccountModel.findOneAndUpdate(
+                        {email: 'tester@valid.com'},
+                        {$pullAll: {values: ['one']}},
+                        {'new': true},
+                        function (err, result) {
+                            expect(result).not.to.be.undefined;
+                            if (result) {
+                                expect(result.values.length).to.equal(1);
+                                expect(result.values[0]).to.equal('two');
+                                done(err);
+                            } else {
+                                done('Error finding item');
+                            }
                         }
-                    });
+                    );
                 });
         });
 
@@ -58,20 +63,25 @@ describe('Mockgoose Update Tests', function () {
                     {name: 'three'}
                 ]},
                 function () {
-                    AccountModel.findOneAndUpdate({email: 'multiples@valid.com'}, {$pullAll: {values: [{name:'one'},{name:'two'}]}}, function (err, result) {
-                        expect(result).not.to.be.undefined;
-                        if (result) {
-                            expect(result.values.length).to.equal(1);
-                            if (result.values.length === 1) {
-                                expect(result.values[0].name).to.equal('three');
-                                done(err);
+                    AccountModel.findOneAndUpdate(
+                        {email: 'multiples@valid.com'},
+                        {$pullAll: {values: [{name:'one'},{name:'two'}]}},
+                        {'new': true},
+                        function (err, result) {
+                            expect(result).not.to.be.undefined;
+                            if (result) {
+                                expect(result.values.length).to.equal(1);
+                                if (result.values.length === 1) {
+                                    expect(result.values[0].name).to.equal('three');
+                                    done(err);
+                                } else {
+                                    done('invalid values length');
+                                }
                             } else {
-                                done('invalid values length');
+                                done('Error finding models');
                             }
-                        } else {
-                            done('Error finding models');
                         }
-                    });
+                    );
                 });
         });
     });

--- a/test/operations/PullOperation.spec.js
+++ b/test/operations/PullOperation.spec.js
@@ -2,7 +2,7 @@
 /*jshint -W079 */ //redefined expect
 'use strict';
 
-var mockgoose = require('../../../Mockgoose');
+var mockgoose = require('../../');
 var Mongoose = require('mongoose').Mongoose;
 var mongoose = new Mongoose();
 mockgoose(mongoose);

--- a/test/operations/PullOperation.spec.js
+++ b/test/operations/PullOperation.spec.js
@@ -45,16 +45,21 @@ describe('Mockgoose Update Tests', function () {
             AccountModel.create(
                 {email: 'tester@valid.com', password: 'password', values: ['one', 'two']},
                 function () {
-                    AccountModel.findOneAndUpdate({email: 'tester@valid.com'}, {$pull: {values: 'one'}}, function (err, result) {
-                        expect(result).not.to.be.undefined;
-                        if (result) {
-                            expect(result.values.length).to.equal(1);
-                            expect(result.values[0]).to.equal('two');
-                            done(err);
-                        } else {
-                            done('Error finding item');
+                    AccountModel.findOneAndUpdate(
+                        {email: 'tester@valid.com'},
+                        {$pull: {values: 'one'}},
+                        {'new': true},
+                        function (err, result) {
+                            expect(result).not.to.be.undefined;
+                            if (result) {
+                                expect(result.values.length).to.equal(1);
+                                expect(result.values[0]).to.equal('two');
+                                done(err);
+                            } else {
+                                done('Error finding item');
+                            }
                         }
-                    });
+                    );
                 }
             );
         });
@@ -89,7 +94,11 @@ describe('Mockgoose Update Tests', function () {
                     });
                 }
             ], function (err, result) {
-                CompanyEntry.findOneAndUpdate({name: 'Test Company'}, {$pull: {users: result.users[0]}}, function (err, result) {
+                CompanyEntry.findOneAndUpdate(
+                {name: 'Test Company'},
+                {$pull: {users: result.users[0]}},
+                {'new': true},
+                function (err, result) {
                     expect(err).not.to.be.ok;
                     expect(result.users.length).to.equal(0);
                     done();
@@ -105,21 +114,27 @@ describe('Mockgoose Update Tests', function () {
                     {name: 'two'}
                 ]},
                 function () {
-                    AccountModel.findOneAndUpdate({email: 'multiples@valid.com'}, {$pull: {values: {name: {$in: ['one']}}}}, function (err, result) {
-                        expect(result).not.to.be.undefined;
-                        if (result) {
-                            expect(result.values.length).to.equal(1);
-                            if (result.values.length === 1) {
-                                expect(result.values[0].name).to.equal('two');
-                                done(err);
+                    AccountModel.findOneAndUpdate(
+                        {email: 'multiples@valid.com'},
+                        {$pull: {values: {name: {$in: ['one']}}}},
+                        {'new': true},
+                        function (err, result) {
+                            expect(result).not.to.be.undefined;
+                            if (result) {
+                                expect(result.values.length).to.equal(1);
+                                if (result.values.length === 1) {
+                                    expect(result.values[0].name).to.equal('two');
+                                    done(err);
+                                } else {
+                                    done('Invalid value length', result.values);
+                                }
                             } else {
-                                done('Invalid value length', result.values);
+                                done('Error finding models');
                             }
-                        } else {
-                            done('Error finding models');
                         }
-                    });
-                });
+                    );
+                }
+            );
         });
 
         it('should be able to pull multiple items from nested documents array by property', function (done) {
@@ -130,21 +145,27 @@ describe('Mockgoose Update Tests', function () {
                     {name: 'three'}
                 ]},
                 function () {
-                    AccountModel.findOneAndUpdate({email: 'multiples@valid.com'}, {$pull: {values: {name: {$in: ['one', 'two']}}}}, function (err, result) {
-                        expect(result).not.to.be.undefined;
-                        if (result) {
-                            expect(result.values.length).to.equal(1);
-                            if (result.values.length === 1) {
-                                expect(result.values[0].name).to.equal('three');
-                                done(err);
+                    AccountModel.findOneAndUpdate(
+                        {email: 'multiples@valid.com'},
+                        {$pull: {values: {name: {$in: ['one', 'two']}}}},
+                        {'new': true},
+                        function (err, result) {
+                            expect(result).not.to.be.undefined;
+                            if (result) {
+                                expect(result.values.length).to.equal(1);
+                                if (result.values.length === 1) {
+                                    expect(result.values[0].name).to.equal('three');
+                                    done(err);
+                                } else {
+                                    done('invalid values length');
+                                }
                             } else {
-                                done('invalid values length');
+                                done('Error finding models');
                             }
-                        } else {
-                            done('Error finding models');
                         }
-                    });
-                });
+                    );
+                }
+            );
         });
     });
 });

--- a/test/operations/PushAllOperation.spec.js
+++ b/test/operations/PushAllOperation.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 describe('Mockgoose Update Tests', function () {
     'use strict';
 
-    var mockgoose = require('../../../Mockgoose');
+    var mockgoose = require('../..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/operations/PushAllOperation.spec.js
+++ b/test/operations/PushAllOperation.spec.js
@@ -21,7 +21,8 @@ describe('Mockgoose Update Tests', function () {
                 expect(err).not.to.be.ok;
                 expect(models).to.be.ok;
                 done(err);
-            });
+            }
+        );
     });
 
     afterEach(function (done) {
@@ -44,7 +45,7 @@ describe('Mockgoose Update Tests', function () {
                     if (result) {
                         AccountModel.update({email: 'pushed@pushed.com'}, {$pushAll: {values: [{name: 'pushed'}]}}, function (err, result) {
                             expect(err).not.to.be.ok;
-                            expect(result).to.equal(1);
+                            expect(result.n).to.equal(1);
                             if (result) {
                                 AccountModel.findOne({email: 'pushed@pushed.com'}, function (err, pushed) {
                                     expect(err).not.to.be.ok;
@@ -62,7 +63,8 @@ describe('Mockgoose Update Tests', function () {
                     } else {
                         done('Error creating model');
                     }
-                });
+                }
+            );
         });
 
         it('should be able to use $pushAll with a update', function (done) {
@@ -77,7 +79,7 @@ describe('Mockgoose Update Tests', function () {
                     if (result) {
                         result.update({$pushAll: {values: [{name: 'pushed'}, {name: 'last'}]}}, function (err, result) {
                             expect(err).not.to.be.ok;
-                            expect(result).to.equal(1);
+                            expect(result.n).to.equal(1);
                             if (result) {
                                 AccountModel.findOne({email: 'pushed@pushed.com'}, function (err, pushed) {
                                     expect(err).not.to.be.ok;
@@ -98,7 +100,8 @@ describe('Mockgoose Update Tests', function () {
                     } else {
                         done('Error creating model');
                     }
-                });
+                }
+            );
         });
 
         it('should be able to use $pushAll with a multi 0  update', function (done) {
@@ -109,7 +112,7 @@ describe('Mockgoose Update Tests', function () {
                     if (result) {
                         AccountModel.update({}, {$pushAll: {values: ['pushed']}}, {multi: 0, sort: {email: 1}}, function (err, result) {
                             expect(err).not.to.be.ok;
-                            expect(result).to.equal(1);
+                            expect(result.n).to.equal(1);
                             if (result) {
                                 AccountModel.find({values: {$in: ['pushed']}}, function (err, pushed) {
                                     expect(err).not.to.be.ok;
@@ -128,7 +131,8 @@ describe('Mockgoose Update Tests', function () {
                     } else {
                         done('Error creating model');
                     }
-                });
+                }
+            );
         });
 
         it('should be able to use $pushAll with a multi 1  update', function (done) {
@@ -139,7 +143,7 @@ describe('Mockgoose Update Tests', function () {
                     if (result) {
                         AccountModel.update({}, {$pushAll: {values: ['pushed']}}, {multi: 1}, function (err, result) {
                             expect(err).not.to.be.ok;
-                            expect(result).to.equal(3);
+                            expect(result.n).to.equal(3);
                             if (result) {
                                 AccountModel.find({values: {$in: ['pushed']}}, function (err, pushed) {
                                     expect(err).not.to.be.ok;
@@ -163,7 +167,8 @@ describe('Mockgoose Update Tests', function () {
                     } else {
                         done('Error creating model');
                     }
-                });
+                }
+            );
         });
     });
 

--- a/test/operations/PushOperation.spec.js
+++ b/test/operations/PushOperation.spec.js
@@ -31,7 +31,6 @@ describe('Mockgoose Update Tests', function () {
     });
 
     describe('$push', function () {
-
         it('should be able to use $push with a static update', function (done) {
             AccountModel.create({email: 'pushed@pushed.com', password: 'password', values: [
                     {name: 'one'},
@@ -44,7 +43,7 @@ describe('Mockgoose Update Tests', function () {
                     if (result) {
                         AccountModel.update({email: 'pushed@pushed.com'}, {$push: {values: {name: 'pushed'}}}, function (err, result) {
                             expect(err).not.to.be.ok;
-                            expect(result).to.equal(1);
+                            expect(result.n).to.equal(1);
                             if (result) {
                                 AccountModel.findOne({email: 'pushed@pushed.com'}, function (err, pushed) {
                                     expect(err).not.to.be.ok;
@@ -77,7 +76,7 @@ describe('Mockgoose Update Tests', function () {
                     if (result) {
                         result.update({$push: {values: {name: 'pushed'}}}, function (err, result) {
                             expect(err).not.to.be.ok;
-                            expect(result).to.equal(1);
+                            expect(result.n).to.equal(1);
                             if (result) {
                                 AccountModel.findOne({email: 'pushed@pushed.com'}, function (err, pushed) {
                                     expect(err).not.to.be.ok;
@@ -114,7 +113,7 @@ describe('Mockgoose Update Tests', function () {
                             {name: 'pushed2'}
                         ]}}}, function (err, result) {
                             expect(err).not.to.be.ok;
-                            expect(result).to.equal(1);
+                            expect(result.n).to.equal(1);
                             if (result) {
                                 AccountModel.findOne({email: 'pushed@pushed.com'}, function (err, pushed) {
                                     expect(err).not.to.be.ok;
@@ -144,7 +143,7 @@ describe('Mockgoose Update Tests', function () {
                     if (result) {
                         AccountModel.update({}, {$push: {values: 'pushed'}}, {multi: 0, sort: {email: 1}}, function (err, result) {
                             expect(err).not.to.be.ok;
-                            expect(result).to.equal(1);
+                            expect(result.n).to.equal(1);
                             if (result) {
                                 AccountModel.find({values: {$in: ['pushed']}}, function (err, pushed) {
                                     expect(err).not.to.be.ok;
@@ -174,7 +173,7 @@ describe('Mockgoose Update Tests', function () {
                     if (result) {
                         AccountModel.update({}, {$push: {values: 'pushed'}}, {multi: 1}, function (err, result) {
                             expect(err).not.to.be.ok;
-                            expect(result).to.equal(3);
+                            expect(result.n).to.equal(3);
                             if (result) {
                                 AccountModel.find({values: {$in: ['pushed']}}, function (err, pushed) {
                                     expect(err).not.to.be.ok;

--- a/test/operations/PushOperation.spec.js
+++ b/test/operations/PushOperation.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 describe('Mockgoose Update Tests', function () {
     'use strict';
 
-    var mockgoose = require('../../../Mockgoose');
+    var mockgoose = require('../..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/operations/SetOnInsertOperation.spec.js
+++ b/test/operations/SetOnInsertOperation.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 describe('Mockgoose $setOnInsert Operation Tests', function () {
     'use strict';
 
-    var mockgoose = require('../../Mockgoose');
+    var mockgoose = require('../..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/operations/SetOperation.spec.js
+++ b/test/operations/SetOperation.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 describe('Mockgoose $set Operation Tests', function () {
     'use strict';
 
-    var mockgoose = require('../../Mockgoose');
+    var mockgoose = require('../..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/operations/UnsetOperation.spec.js
+++ b/test/operations/UnsetOperation.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 describe('Mockgoose $UNSET Operation Tests', function () {
 	'use strict';
 
-	var mockgoose = require('../../Mockgoose');
+	var mockgoose = require('../..');
 	var Mongoose = require('mongoose').Mongoose;
 	var mongoose = new Mongoose();
 	mockgoose(mongoose);

--- a/test/operations/UnsetOperation.spec.js
+++ b/test/operations/UnsetOperation.spec.js
@@ -33,26 +33,39 @@ describe('Mockgoose $UNSET Operation Tests', function () {
 	describe('$unset', function () {
 
 		it('Be able to ignore non-existent fields', function(done) {
-			SimpleModel.findOneAndUpdate({name: 'rex'}, {$unset: {doesNotExist: ''}}, function(err, res) {
-				expect(res.value).to.equal('hi');
-				expect(res.bool).to.equal(true);
-				done(err);
-			});
+			SimpleModel.findOneAndUpdate(
+				{name: 'rex'},
+				{$unset: {doesNotExist: ''}},
+				{'new': true},
+				function(err, res) {
+					expect(res.value).to.equal('hi');
+					expect(res.bool).to.equal(true);
+					done(err);
+				}
+			);
 		});
 
 		it('Be able to unset a value', function(done) {
-			SimpleModel.findOneAndUpdate({name: 'rex'}, {$unset: {value: ''}}, function(err, res) {
-				expect(res.value).to.equal(undefined);
-				done(err);
-			});
+			SimpleModel.findOneAndUpdate(
+				{name: 'rex'},
+				{$unset: {value: ''}},
+				{'new': true},
+				function(err, res) {
+					expect(res.value).to.equal(undefined);
+					done(err);
+				});
 		});
 
 		it('Be able to unset multiple values', function(done) {
-			SimpleModel.findOneAndUpdate({name: 'rex'}, {$unset: {value: '', bool: ''}}, function(err, res) {
-				expect(res.value).to.equal(undefined);
-				expect(res.bool).to.equal(undefined);
-				done(err);
-			});
+			SimpleModel.findOneAndUpdate(
+				{name: 'rex'},
+				{$unset: {value: '', bool: ''}},
+				{'new': true},
+				function(err, res) {
+					expect(res.value).to.equal(undefined);
+					expect(res.bool).to.equal(undefined);
+					done(err);
+				});
 		});
 	});
 });

--- a/test/operations/array/positional.spec.js
+++ b/test/operations/array/positional.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 describe('$(update) http://docs.mongodb.org/manual/reference/operator/update/positional/', function () {
     'use strict';
 
-    var mockgoose = require('./../../../Mockgoose');
+    var mockgoose = require('../../..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/operations/array/positional.spec.js
+++ b/test/operations/array/positional.spec.js
@@ -94,16 +94,19 @@ describe('$(update) http://docs.mongodb.org/manual/reference/operator/update/pos
 
             it('Not throw an error when using the update positional operator.', function (done) {
                 expect(function () {
-                    Model.findOneAndUpdate({ p: 'SomeId', 'grps.grpId': 'SomeGrpId' }, {
+                    Model.findOneAndUpdate(
+                        { p: 'SomeId', 'grps.grpId': 'SomeGrpId' }, {
                         '$push': {
                             'grps.$.attrs': {
                                 attrId: 'SomeNewAttrId'
                             }
-                        }
-                    }).exec().then(function (model) {
-                            expect(model.grps[0].attrs[1].attrId).to.equal('SomeNewAttrId');
-                            done();
-                        });
+                        },
+                    },
+                    {'new': true}).
+                    exec().then(function (model) {
+                        expect(model.grps[0].attrs[1].attrId).to.equal('SomeNewAttrId');
+                        done();
+                    });
                 }).not.to.throw();
             });
         });
@@ -147,16 +150,19 @@ describe('$(update) http://docs.mongodb.org/manual/reference/operator/update/pos
 
             it('$Pull does not work with nested arrays and positional operator', function (done) {
                 expect(function () {
-                    Model.findOneAndUpdate({ p: 'SomeId', 'grps.grpId': 'SomeGrpId' }, {
+                    Model.findOneAndUpdate(
+                        { p: 'SomeId', 'grps.grpId': 'SomeGrpId' }, {
                         '$pull': {
                             'grps.$.attrs': {
                                 attrId: 'SomeAttrId'
                             }
                         }
-                    }).exec().then(function (model) {
-                            expect(model.grps[0].attrs.length).to.equal(0);
-                            done();
-                        });
+                    },
+                    {'new': true}).
+                    exec().then(function (model) {
+                        expect(model.grps[0].attrs.length).to.equal(0);
+                        done();
+                    });
                 }).not.to.throw();
             });
         });

--- a/test/operations/comparison/GreaterThanOperation.spec.js
+++ b/test/operations/comparison/GreaterThanOperation.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 describe('Mockgoose $gt Tests', function () {
     'use strict';
 
-    var mockgoose = require('./../../../Mockgoose');
+    var mockgoose = require('../../..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/operations/comparison/GreaterThanOrEqualOperation.spec.js
+++ b/test/operations/comparison/GreaterThanOrEqualOperation.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 describe('Mockgoose $gte Tests', function () {
     'use strict';
 
-    var mockgoose = require('./../../../Mockgoose');
+    var mockgoose = require('../../..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/operations/comparison/InOperation.spec.js
+++ b/test/operations/comparison/InOperation.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 describe('Mockgoose Find Tests', function () {
     'use strict';
 
-    var mockgoose = require('./../../../Mockgoose');
+    var mockgoose = require('../../..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/operations/comparison/LessThanOperation.spec.js
+++ b/test/operations/comparison/LessThanOperation.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 describe('Mockgoose $lt Tests', function () {
     'use strict';
 
-    var mockgoose = require('./../../../Mockgoose');
+    var mockgoose = require('../../..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/operations/comparison/LessThanOrEqualOperation.spec.js
+++ b/test/operations/comparison/LessThanOrEqualOperation.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 describe('Mockgoose $lte Tests', function () {
     'use strict';
 
-    var mockgoose = require('./../../../Mockgoose');
+    var mockgoose = require('../../..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/operations/comparison/NEOperation.spec.js
+++ b/test/operations/comparison/NEOperation.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 describe('Mockgoose $ne Tests', function () {
     'use strict';
 
-    var mockgoose = require('./../../../Mockgoose');
+    var mockgoose = require('../../..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/operations/comparison/NINOperation.spec.js
+++ b/test/operations/comparison/NINOperation.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 describe('Mockgoose $nin', function () {
     'use strict';
 
-    var mockgoose = require('../../../Mockgoose');
+    var mockgoose = require('../../..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
 	mockgoose(mongoose);

--- a/test/operations/evaluation/RegExpOperation.spec.js
+++ b/test/operations/evaluation/RegExpOperation.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 describe('Mockgoose $regex Tests', function () {
     'use strict';
 
-    var mockgoose = require('./../../../Mockgoose');
+    var mockgoose = require('../../..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/operations/logical/AndOperation.spec.js
+++ b/test/operations/logical/AndOperation.spec.js
@@ -60,7 +60,6 @@ describe('Mockgoose $and Tests', function () {
     });
 
     describe('$and Tests', function () {
-
         it('Find values that match $and operation', function (done) {
             Model.find({ $and: [
                 { price: 1.99 },
@@ -69,7 +68,8 @@ describe('Mockgoose $and Tests', function () {
             ] }).exec().then(function (results) {
                     expect(results.length).to.equal(2);
                     done();
-                });
+                }
+            );
         });
 
         it('Find values that match implicit $and operation', function (done) {
@@ -79,14 +79,15 @@ describe('Mockgoose $and Tests', function () {
             });
         });
 
-        it('Find values that match $and operation containing implicit and operations', function (done) {
+        it('Find values that match $and operation containing implicit $and operations', function (done) {
             Model.find({ $and: [
                 { price: 1.99, sale: true },
                 { qty: { $gt: 20 }, sale: true }
             ] }).exec().then(function (results) {
                     expect(results.length).to.equal(2);
                     done();
-                });
+                }
+            );
         });
 
         it('Perform the $and operation on a single field', function (done) {
@@ -94,14 +95,14 @@ describe('Mockgoose $and Tests', function () {
                 { price: { $ne: 1.99 } },
                 { price: { $gt: 0 } }
             ] }, { $set: { qty: 15 } }).exec().then(function (result) {
-                    expect(result).to.equal(1);
-                    done();
-                });
+                expect(result.n).to.equal(1);
+                done();
+            });
         });
 
         it('Perform the $and operation on a single field combined', function (done) {
             Model.update({ price: { $ne: 1.99, $gt: 0 } }, { $set: { qty: 15 } }).exec().then(function (result) {
-                expect(result).to.equal(1);
+                expect(result.n).to.equal(1);
                 done();
             });
         });
@@ -113,7 +114,8 @@ describe('Mockgoose $and Tests', function () {
             ] }).exec().then(function (results) {
                     expect(results.length).to.equal(2);
                     done();
-                });
+                }
+            );
         });
 
         it('$and in an array of values', function (done) {
@@ -127,7 +129,6 @@ describe('Mockgoose $and Tests', function () {
         });
 
         describe('Mongoose', function () {
-
             it('Find values with Mongoose and operation', function (done) {
                 Model.find().and([
                         { price: 1.99 },
@@ -136,13 +137,13 @@ describe('Mockgoose $and Tests', function () {
                     ]).exec().then(function (results) {
                         expect(results.length).to.equal(2);
                         done();
-                    });
+                    }
+                );
             });
         });
     });
 
     describe('$and Tests Bugs', function () {
-
         describe('#41 Unexpected behavior such as null err and result with findOneAndUpdate `$and` queries', function () {
             var AccountModel = require('../../models/AccountModel')(mongoose);
             beforeEach(function(done){

--- a/test/operations/logical/AndOperation.spec.js
+++ b/test/operations/logical/AndOperation.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 describe('Mockgoose $and Tests', function () {
     'use strict';
 
-    var mockgoose = require('./../../../Mockgoose');
+    var mockgoose = require('../../..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/operations/logical/NorOperation.spec.js
+++ b/test/operations/logical/NorOperation.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 describe('Mockgoose $nor Tests', function () {
     'use strict';
 
-    var mockgoose = require('./../../../Mockgoose');
+    var mockgoose = require('../../..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/operations/logical/NotOperation.spec.js
+++ b/test/operations/logical/NotOperation.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 describe('Mockgoose $not Tests', function () {
     'use strict';
 
-    var mockgoose = require('./../../../Mockgoose');
+    var mockgoose = require('../../..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/operations/logical/OrOperation.spec.js
+++ b/test/operations/logical/OrOperation.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 describe('Mockgoose $or Tests', function () {
     'use strict';
 
-    var mockgoose = require('./../../../Mockgoose');
+    var mockgoose = require('../../..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/options/Limit.spec.js
+++ b/test/options/Limit.spec.js
@@ -6,7 +6,7 @@ describe('Mockgoose Limit Tests', function () {
     'use strict';
 
     var async = require('async');
-    var mockgoose = require('./../../Mockgoose');
+    var mockgoose = require('../..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/options/Skip.spec.js
+++ b/test/options/Skip.spec.js
@@ -6,7 +6,7 @@ describe('Mockgoose Skip Tests', function () {
     'use strict';
 
     var async = require('async');
-    var mockgoose = require('./../../Mockgoose');
+    var mockgoose = require('../..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);

--- a/test/options/Sort.spec.js
+++ b/test/options/Sort.spec.js
@@ -5,7 +5,7 @@ var expect = require('chai').expect;
 describe('Mockgoose Find Tests', function () {
     'use strict';
 
-    var mockgoose = require('./../../Mockgoose');
+    var mockgoose = require('../..');
     var Mongoose = require('mongoose').Mongoose;
     var mongoose = new Mongoose();
     mockgoose(mongoose);


### PR DESCRIPTION
This PR adds support for Mongoose 4.x. It's incompatible with Mongoose 3.x but I don't feel bad about that because Mongoose dropped support for 3.x as of 9/1. Someone mentioned in an issue somewhere that Mockgoose should probably bump the version number to 4.x when it moves to Mongoose 4.x so people don't get confused. I think that's a great idea.

This PR was actually branched off of zxqfox's PR #137 and resolves #125. All 251 tests pass in about 30 seconds for me.

Almost all of the changes revolved around two breaking changes:

* The non-error part of the callback to `Model.update` used to be the number of documents that were affected by an update. Now that value is a Object like `{ok: 1, n: 1}` where `n` is the number of objects affected and `ok` is 1 if nothing went wrong or 0 if something did. There is always a non-null error when `ok: 0`.
* The default setting for findOneAndUpdate in Mongoose 4.x changed from `{new: true}` to `{new: false}`. This means that the returned document, by default, is the version before getting updated. I changed all of the tests to explicitly use the option `{new: true}` so the updated document gets returned. I also updated Mockgoose itself to return the correct document based on that option.

My only concern is the tests take about 10 seconds to exit after mocha gives its final output.