### PR TITLE
Update bunyan dependency to get rid of DTRACE warnings under node 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "node": ">=0.10.0"
   },
   "dependencies": {
-    "bunyan": "~1.3.5",
+    "bunyan": "~1.5.1",
     "lodash": "~3.6.0",
     "mongoose": "^4.0.0",
     "mongoosemask": "~0.0.6"


### PR DESCRIPTION
Currently DTRACE binding for  bunyan aren't build with:
```
---------------
Building dtrace-provider failed with exit code 1 and signal 0
re-run install with environment variable V set to see the build output
---------------
```

under node v.4.1.0

And while using Mockgoose I get warnings:
```
{ [Error: Cannot find module './build/Release/DTraceProviderBindings'] code: 'MODULE_NOT_FOUND' }
```

Upgrading bunyan dependency fixes this, while logging seems to be working as expected (no API changes in bunyan from 1.3.X to 1.5.X).