### PR TITLE
Fix dotpath syntax for deep-nested models 

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -216,7 +216,11 @@ function findValue(objectPath, obj) {
                 k++;
                 continue;
             }
-            var values = _.pluck(obj, key);
+            var values = obj.reduce(function(acc, e) {
+                if(!_.isObject(e)) { return acc; }
+                return acc.concat(findValue(objPath.slice(k + 1).join('.'), e));
+            }, []);
+
             if (!_.isUndefined(values[0])) {
                 value = values;
                 break;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,8 @@
 'use strict';
+
+/*jshint -W083*/
+/* ^^ ignore jshint's "Don't make functions within a loop" rule */
+
 var _ = require('lodash');
 var ObjectId = require('./Types').ObjectId;
 var operations = require('./operations/Operations');

--- a/test/Find.spec.js
+++ b/test/Find.spec.js
@@ -12,6 +12,7 @@ describe('Mockgoose Find Tests', function () {
     mongoose.connect('mongodb://localhost/TestingDB-58');
     var AccountModel = require('./models/AccountModel')(mongoose);
     var SimpleModel = require('./models/SimpleModel')(mongoose);
+    var NestedModel = require('./models/NestedModel.js')(mongoose);
     var ObjectId = mongoose.Types.ObjectId;
 
     var accountId;
@@ -36,11 +37,20 @@ describe('Mockgoose Find Tests', function () {
                         expect(one).to.be.ok;
                         expect(two).to.be.ok;
                         expect(three).to.be.ok;
-                        done(err);
+
+                        NestedModel.create(
+                            {foo : [{bar : [{baz : 1}, {baz : 2}, {baz : 3}]}]},
+                            {foo : [{bar : [{baz : 1}]}, {bar : [{baz : 42}]}]},
+                            function(err, m1, m2) {
+                                expect(err).not.to.be.ok;
+                                expect(m1).to.be.ok;
+                                expect(m2).to.be.ok;
+                                done(err);
+                            }
+                        );
                     }
                 );
             });
-
     });
 
     afterEach(function (done) {
@@ -864,6 +874,22 @@ describe('Mockgoose Find Tests', function () {
                     done();
                 });
             });
+        });
+
+        describe('Support any level of nesting (recursive)', function() {
+            it('should match any deep nested value', function(done){
+                NestedModel.find({'foo.bar.baz' : 1}, function(err, models) {
+                    expect(models.length).to.equal(2); 
+                    done();
+                });
+            });
+            it('should match with any subdocument layout', function(done){
+                NestedModel.find({'foo.bar.baz' : 42}, function(err, models) {
+                    expect(models.length).to.equal(1);
+                    done();
+                });
+            });
+
         });
     });
 });

--- a/test/models/NestedModel.js
+++ b/test/models/NestedModel.js
@@ -1,0 +1,15 @@
+'use strict';
+
+var NestedFoo = {
+    foo : [{
+        bar : [
+            {baz : Number},
+        ]
+    }]
+};
+
+
+module.exports = function(mongoose) {
+    var NestedSchema = new mongoose.Schema(NestedFoo);
+    return mongoose.model('DeepNestedEntry', NestedSchema);
+};


### PR DESCRIPTION
a dotpath query wouldn't match a document with more than one level of array nesting.
This PR fix it by making findValue recursive.
