### PR TITLE
Removing need for async library

### DIFF
--- a/Mockgoose.js
+++ b/Mockgoose.js
@@ -75,13 +75,20 @@ module.exports = function(mongoose, db_opts) {
     //         throw err;
     //     }
     // });
-
     module.exports.reset = function(done) {
-        async.each(mongoose.connection.collections, function(obj, callback) {
+        var collections = mongoose.connection.collections,
+            remaining = collections.length;
+        if (remaining === 0) {
+            done(null);
+        }
+        collections.forEach(function(obj) {
             obj.deleteMany(null, function() {
-                callback(null); // ignore errors
+                remaining--;
+                if (remaining === 0) {
+                    done(null);
+                }
             });
-        }, done);
+        });
     };
 
     return emitter;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "node": ">=0.10.0"
   },
   "dependencies": {
-    "async": "^1.5.0",
     "debug": "2.2.0",
     "mongodb-prebuilt": "^4.2.15"
   },


### PR DESCRIPTION
This removes the only use of async and replaces it with a simple counter to offer the same functionality without adding a big library to the project.