### PR TITLE
fix bug preventing connecting twice

### DIFF
--- a/Mockgoose.js
+++ b/Mockgoose.js
@@ -20,11 +20,11 @@ module.exports = function(mongoose, db_opts) {
     }
 
     mongoose.connection.on('disconnected', function () {  
-        console.log('Mongoose disconnected');
+        debug('Mongoose disconnected');
         mongod_emitter.emit('mongoShutdown');
     }); 
 
-    emitter.once("mongodbStarted", function(db_opts) {
+    emitter.on("mongodbStarted", function(db_opts) {
         connect_args[0] = "mongodb://localhost:" + db_opts.port;
         debug("connecting to %s", connect_args[0]);
         orig_connect.apply(mongoose, connect_args);


### PR DESCRIPTION
Connecting again after disconnecting does not work due to the [`once`-handler](https://github.com/mccormicka/Mockgoose/blob/master/Mockgoose.js#L27).

```JavaScript
'use strict';
let mongoose = require('mongoose');
require('mockgoose')(mongoose);

mongoose.connect('mongodb://127.0.0.1:27017/test', err => {
    if(err) return console.log(err);
    console.log('connected. should disconnect in 1s.');
});

setTimeout(() => {
    mongoose.disconnect(err =>{
        if(err) return console.log(err);
        console.log('disconnected');

        mongoose.connect('mongodb://127.0.0.1:27017/test', err => {
            if(err) return console.log(err);
            console.log('connected. should disconnect in 1s.');
        });
    });
}, 1000);

```