### PR TITLE
Fix reset method

### DIFF
--- a/Mockgoose.js
+++ b/Mockgoose.js
@@ -82,12 +82,17 @@ module.exports = function(mongoose, db_opts) {
     // });
     module.exports.reset = function(done) {
         var collections = mongoose.connection.collections,
-            remaining = collections.length;
+            collectionNames = Object.keys(collections),
+            remaining = collectionNames.length;
+
         if (remaining === 0) {
             done(null);
         }
-        collections.forEach(function(obj) {
-            obj.deleteMany(null, function() {
+        
+        collectionNames.forEach(function(name) {
+            var collection = collections[collectionNames];
+
+            collection.deleteMany(null, function() {
                 remaining--;
                 if (remaining === 0) {
                     done(null);

--- a/test/index.js
+++ b/test/index.js
@@ -16,6 +16,12 @@ before(function(done) {
     }); 
 });
 
+after(function(done) {
+  mockgoose.reset(function() {
+    done()
+  });
+});
+
 describe('User functions', function() {
 	it("should create a cat foo", function(done) {
 		Cat.create({name: "foo"}, function(err, cat) {


### PR DESCRIPTION
This fixes: https://github.com/mccormicka/Mockgoose/issues/166

Although I am slightly puzzled how the original PR worked, given that `mongoose.connection.collections` returns an object rather than an array...