### PR TITLE
support mocking at the Connection#open level

### DIFF
--- a/Mockgoose.js
+++ b/Mockgoose.js
@@ -16,29 +16,72 @@ var server_started = false;
 var mongod_emitter;
 
 module.exports = function(mongoose, db_opts) {
-    var orig_connect = mongoose.connect;
+    var ConnectionPrototype = mongoose.Connection.prototype;
+    var origOpen = ConnectionPrototype.open;
+    var origOpenPrivate = ConnectionPrototype._open;
+    var openCallList = [];
 
-	// caching original connect arguments for unmock method
-	var orig_connect_uri;
+    ConnectionPrototype.open = function() {
+        var connection = this;
+        var args = arguments;
+        openCallList.push({
+            connection: connection,
+            args: args,
+            isConnected: false,
+        });
 
-    var connect_args;
-    mongoose.connect = function() {
-        connect_args = arguments;
-		orig_connect_uri = connect_args[0];
-        start_server(db_opts);
+        function resume() {
+            origOpen.apply(connection, args);
+        }
+        if (mongod_emitter === undefined) {
+            start_server(db_opts);
+            emitter.once("mongodbStarted", resume);
+        }
+        else {
+            resume();
+        }
     }
 
-	mongoose.isMocked = true;
+    ConnectionPrototype._open = function() {
+        if (mongod_emitter === undefined) {
+            origOpenPrivate.apply(this, arguments);
+            return;
+        }
 
-    mongoose.connection.on('disconnected', function () {  
-        debug('Mongoose disconnected');
-        mongod_emitter.emit('mongoShutdown');
-    }); 
+        this.host = 'localhost';
+        this.port = db_opts.port;
 
-    emitter.on("mongodbStarted", function(db_opts) {
-        connect_args[0] = "mongodb://localhost:" + db_opts.port;
-        debug("connecting to %s", connect_args[0]);
-        orig_connect.apply(mongoose, connect_args);
+        var connection = this;
+        openCallList.filter(function(call, index) {
+            if (call.connection !== connection) {
+                return false;
+            }
+
+            connection.once('connected', function() {
+                call.isConnected = true;
+                debug('Mongoose connected %d', index);
+            });
+            connection.once('disconnected', function() {
+                call.isConnected = false;
+                debug('Mongoose disconnected %d', index);
+
+                if (! openCallList.some(function(_call) {
+                    return _call.isConnected;
+                }) && (mongod_emitter !== undefined)) {
+                    mongod_emitter.emit('mongoShutdown');
+                }
+            });
+            return true;
+        });
+
+        origOpenPrivate.apply(this, arguments);
+    }
+
+
+    mongoose.isMocked = true;
+
+    emitter.once("mongodbStarted", function(db_opts) {
+        debug("started server on port: %d", db_opts.port);
     });
 
     if (!db_opts) db_opts = {};
@@ -100,46 +143,89 @@ module.exports = function(mongoose, db_opts) {
     }
 
     module.exports.reset = function(done) {
-        var collections = mongoose.connection.collections;
-        var remaining = Object.keys(collections).length;
-
-        if (remaining === 0) {
-            done(null);
+        if (! mongoose.isMocked) {
+            return done(null);
         }
-		for( var collection_name in collections ) {
-			var obj = collections[collection_name];
-        	obj.deleteMany(null, function() {
-        	    remaining--;
-        	    if (remaining === 0) {
-        	        done(null);
-        	    }
-        	});
-		}
+
+        var collections = openCallList.reduce(function(total, call) {
+            var objs = call.connection.collections;
+            for (var key in objs) {
+                total.push(objs[key]);
+            }
+            return total;
+        }, []);
+
+        var remaining = collections.length;
+        if (remaining === 0) {
+            return done(null);
+        }
+
+        collections.forEach(function(obj) {
+            obj.deleteMany(null, function() {
+                remaining--;
+                if (remaining === 0) {
+                    done(null);
+                }
+            });
+        });
     };
 
 	mongoose.unmock = function(callback) {
-		mongoose.disconnect(function() {
-			delete mongoose.isMocked;
-			connect_args[0] = orig_connect_uri;
-			mongoose.connect = orig_connect;
-			emitter.removeAllListeners();
-			callback();
-		});
+        function restore() {
+            delete mongoose.isMocked;
+
+            ConnectionPrototype.open = origOpen;
+            ConnectionPrototype._open = origOpenPrivate;
+            openCallList = [];
+
+            emitter.removeAllListeners();
+            mongod_emitter = undefined;
+
+            callback && callback();
+        }
+
+        if ((! this.isMocked) || (openCallList.length === 0)) {
+            return restore();
+        }
+
+        openCallList.forEach(function(call) {
+            call.connection.close();
+        });
+        mongod_emitter.once('mongoShutdown', restore);
 	}
 
 	mongoose.unmockAndReconnect = function(callback) {
-		mongoose.unmock(function() {
-			var overloaded_callback = function(err) {
-				callback(err);
-			}
-			// mongoose connect prototype connect(String, Object?, Function?)
-			if ( connect_args[2] && typeof connect_args[2] === "function" ) {
-				connect_args[2] = overloaded_callback;
-			} else {
-				connect_args[1] = overloaded_callback;
-			}
+        var reconnectCallList = openCallList;
+        var remaining = openCallList.length;
 
-			orig_connect.apply(mongoose, connect_args);
+		mongoose.unmock(function() {
+            if (remaining === 0) {
+                callback && callback();
+                return;
+            }
+
+            var anyError;
+            reconnectCallList.forEach(function(call, index) {
+                var connection = call.connection;
+                var args = Array.prototype.slice.call(call.args);
+                var cb = args.pop();
+                if (typeof cb !== 'function') {
+                    args.push(cb);
+                }
+
+                args.push(function(err) {
+                    debug('Mongoose reconnected %d', index);
+
+                    anyError = anyError || err;
+
+                    remaining--;
+                    if ((remaining === 0)) {
+                        callback && callback(anyError);
+                    }
+                });
+
+                connection.open.apply(connection, args);
+            });
 		});
 	}
 

--- a/package.json
+++ b/package.json
@@ -34,9 +34,11 @@
     "mongodb-prebuilt": "^4.4.9"
   },
   "devDependencies": {
+    "async": "~1.5.2",
     "chai": "~2.2.0",
     "mocha": "~2.2.4",
-    "mongoose": "*"
+    "mongoose": "*",
+    "sinon": "~1.17.3"
   },
   "bugs": {
     "url": "https://github.com/mccormicka/Mockgoose/issues"

--- a/test/index.js
+++ b/test/index.js
@@ -10,10 +10,18 @@ var Cat = mongoose.model('Cat', { name: String });
 
 mockgoose(mongoose);
 
+// FIXME: patiently wait for mongod to shut down
+//   or else we can't guarantee :27017 across tests
+var FIXME_INTER_TEST_DELAY = 1000;
+
+
 before(function(done) {
     mongoose.connect('mongodb://127.0.0.1:27017/TestingDB', function(err) {
         done(err);
-    }); 
+    });
+});
+after(function(done) {
+    setTimeout(done, FIXME_INTER_TEST_DELAY);
 });
 
 describe('User functions', function() {

--- a/test/interception.js
+++ b/test/interception.js
@@ -18,13 +18,18 @@ var HOST = '127.0.0.1'; // because `process.env.MOCKGOOSE_LIVE`
 var DB = 'DB';
 var DB2 = 'DB2';
 var PORT = 27017;
-var MOCK_OPTIONS = {
-    port: 27027
-};
 var HOST_DB_PORT = [ HOST, DB, PORT ];
 var HOST_DB2_PORT = [ HOST, DB2, PORT ];
-var MOCK_DB_PORT = [ 'localhost', DB, MOCK_OPTIONS.port ];
-var MOCK_DB2_PORT = [ 'localhost', DB2, MOCK_OPTIONS.port ];
+
+// FIXME: avoiding the default :27017
+var FIXME_OPTIONS = {
+    port: 27027
+};
+// FIXME: patiently wait for mongod to shut down
+//   or else we can't guarantee :27017 across tests
+var FIXME_INTER_TEST_DELAY = 1000;
+var MOCK_DB_PORT = [ 'localhost', DB, FIXME_OPTIONS.port ];
+var MOCK_DB2_PORT = [ 'localhost', DB2, FIXME_OPTIONS.port ];
 
 
 describe('mongoose.Connection', function() {
@@ -38,9 +43,7 @@ describe('mongoose.Connection', function() {
             // AFTER we've put back any spys & stubs
             sandbox.restore();
 
-            // patiently wait for mongod to shut down
-            //   or else we can't guarantee :27017 across tests
-            setTimeout(done, 200);
+            setTimeout(done, FIXME_INTER_TEST_DELAY);
         });
     });
 
@@ -69,7 +72,7 @@ describe('mongoose.Connection', function() {
             });
 
             // AFTER we apply the spys & stubs
-            mockgoose(mongoose, MOCK_OPTIONS);
+            mockgoose(mongoose, FIXME_OPTIONS);
         });
 
 

--- a/test/interception.js
+++ b/test/interception.js
@@ -1,0 +1,200 @@
+'use strict';
+
+var expect = require('chai').expect;
+var sinon = require('sinon');
+var async = require('async');
+
+var mongooseLib = require('mongoose');
+var Connection = mongooseLib.Connection;
+var ConnectionPrototype = Connection.prototype;
+var Mongoose = mongooseLib.Mongoose;
+var mockgoose = require('../Mockgoose');
+
+var sandbox = sinon.sandbox.create();
+var mongoose;
+
+var CONNECTION_BASE = { options: {} };
+var HOST = '127.0.0.1'; // because `process.env.MOCKGOOSE_LIVE`
+var DB = 'DB';
+var DB2 = 'DB2';
+var PORT = 27017;
+var MOCK_OPTIONS = {
+    port: 27027
+};
+var HOST_DB_PORT = [ HOST, DB, PORT ];
+var HOST_DB2_PORT = [ HOST, DB2, PORT ];
+var MOCK_DB_PORT = [ 'localhost', DB, MOCK_OPTIONS.port ];
+var MOCK_DB2_PORT = [ 'localhost', DB2, MOCK_OPTIONS.port ];
+
+
+describe('mongoose.Connection', function() {
+    beforeEach(function() {
+        mongoose = new Mongoose();
+    });
+
+    afterEach(function(done) {
+        // safety in the face of assertion failure
+        mongoose.unmock(function() {
+            // AFTER we've put back any spys & stubs
+            sandbox.restore();
+
+            // patiently wait for mongod to shut down
+            //   or else we can't guarantee :27017 across tests
+            setTimeout(done, 200);
+        });
+    });
+
+
+    describe('#open', function() {
+        var connections;
+        var openSpy, _openStub;
+        var _openState;
+
+        beforeEach(function() {
+            connections = [];
+            _openState = [];
+
+            // #open (eg. to the mock DB) as usual
+            openSpy = sandbox.spy(ConnectionPrototype, 'open');
+
+            var _openOriginal = ConnectionPrototype._open;
+            _openStub = sandbox.stub(ConnectionPrototype, '_open', function() {
+                // the host & port get faked out
+                _openState.push([
+                    this.host, this.name, this.port,
+                ]);
+
+                // other than that, #_open as usual
+                _openOriginal.apply(this, arguments);
+            });
+
+            // AFTER we apply the spys & stubs
+            mockgoose(mongoose, MOCK_OPTIONS);
+        });
+
+
+        describe('followed by #unmock', function() {
+            it('fakes out a single call', function(done) {
+                async.series([
+                    function(next) {
+                        connections.push(new Connection(CONNECTION_BASE));
+                        connections[0].open(HOST, DB, PORT, next);
+                    },
+                    function(next) {
+                        mongoose.unmock(next);
+                    },
+                    function(next) {
+                        expect(openSpy.callCount).to.equal(1);
+                        // connect
+                        expect(openSpy.args[0].slice(0, 3)).to.deep.equal(HOST_DB_PORT);
+
+                        expect(openSpy.callCount).to.equal(1);
+                        // connect (+ mock)
+                        expect(_openState[0]).to.deep.equal(MOCK_DB_PORT);
+
+                        next();
+                    },
+                ], done);
+            });
+
+            it('fakes out more than one call', function(done) {
+                async.series([
+                    function(next) {
+                        connections.push(new Connection(CONNECTION_BASE));
+                        connections[0].open(HOST, DB, PORT, next);
+                    },
+                    function(next) {
+                        connections.push(new Connection(CONNECTION_BASE));
+                        connections[1].open(HOST, DB2, PORT, next);
+                    },
+                    function(next) {
+                        mongoose.unmock(next);
+                    },
+                    function(next) {
+                        expect(openSpy.callCount).to.equal(2);
+                        // connect
+                        expect(openSpy.args[0].slice(0, 3)).to.deep.equal(HOST_DB_PORT);
+                        expect(openSpy.args[1].slice(0, 3)).to.deep.equal(HOST_DB2_PORT);
+
+                        expect(openSpy.callCount).to.equal(2);
+                        // connect (+ mock)
+                        expect(_openState[0]).to.deep.equal(MOCK_DB_PORT);
+                        expect(_openState[1]).to.deep.equal(MOCK_DB2_PORT);
+
+                        next();
+                    },
+                ], done);
+            });
+        });
+
+
+        describe('with a reconnect', function() {
+            if (! process.env.MOCKGOOSE_LIVE) {
+                return;
+            }
+
+
+            it('reconnects a single call', function(done) {
+                async.series([
+                    function(next) {
+                        connections.push(new Connection(CONNECTION_BASE));
+                        connections[0].open(HOST, DB, PORT, next);
+                    },
+                    function(next) {
+                        mongoose.unmockAndReconnect(next);
+                    },
+                    function(next) {
+                        expect(openSpy.callCount).to.equal(2);
+                        // connect
+                        expect(openSpy.args[0].slice(0, 3)).to.deep.equal(HOST_DB_PORT);
+                        // reconnect
+                        expect(openSpy.args[1].slice(0, 3)).to.deep.equal(HOST_DB_PORT);
+
+                        expect(openSpy.callCount).to.equal(2);
+                        // connect (+ mock)
+                        expect(_openState[0]).to.deep.equal(MOCK_DB_PORT);
+                        // reconnect
+                        expect(_openState[1]).to.deep.equal(HOST_DB_PORT);
+
+                        next();
+                    },
+                ], done);
+            });
+
+            it('reconnects more than one call', function(done) {
+                async.series([
+                    function(next) {
+                        connections.push(new Connection(CONNECTION_BASE));
+                        connections[0].open(HOST, DB, PORT, next);
+                    },
+                    function(next) {
+                        connections.push(new Connection(CONNECTION_BASE));
+                        connections[1].open(HOST, DB2, PORT, next);
+                    },
+                    function(next) {
+                        mongoose.unmockAndReconnect(next);
+                    },
+                    function(next) {
+                        expect(openSpy.callCount).to.equal(4);
+                        // connect
+                        expect(openSpy.args[0].slice(0, 3)).to.deep.equal(HOST_DB_PORT);
+                        expect(openSpy.args[1].slice(0, 3)).to.deep.equal(HOST_DB2_PORT);
+                        // reconnect
+                        expect(openSpy.args[2].slice(0, 3)).to.deep.equal(HOST_DB_PORT);
+                        expect(openSpy.args[3].slice(0, 3)).to.deep.equal(HOST_DB2_PORT);
+
+                        expect(openSpy.callCount).to.equal(4);
+                        // connect (+ mock)
+                        expect(_openState[0]).to.deep.equal(MOCK_DB_PORT);
+                        expect(_openState[1]).to.deep.equal(MOCK_DB2_PORT);
+                        // reconnect
+                        expect(_openState[2]).to.deep.equal(HOST_DB_PORT);
+                        expect(_openState[3]).to.deep.equal(HOST_DB2_PORT);
+
+                        next();
+                    },
+                ], done);
+            });
+        });
+    });
+});

--- a/test/permutations.js
+++ b/test/permutations.js
@@ -1,0 +1,414 @@
+'use strict';
+
+var expect = require('chai').expect;
+var sinon = require('sinon');
+var async = require('async');
+
+var mongooseLib = require('mongoose');
+var Connection = mongooseLib.Connection;
+var ConnectionPrototype = Connection.prototype;
+var Mongoose = mongooseLib.Mongoose;
+var mockgoose = require('../Mockgoose');
+
+var sandbox = sinon.sandbox.create();
+var mongoose;
+
+var CONNECTION_BASE = { options: {} };
+var HOST = '127.0.0.1'; // because `process.env.MOCKGOOSE_LIVE`
+var DB = 'DB';
+var DB2 = 'DB2';
+var PORT = 27017;
+var MOCK_HOST = 'localhost';
+var MOCK_OPTIONS = {
+    port: 27027
+};
+
+
+describe('mockgoose', function() {
+    beforeEach(function() {
+        mongoose = new Mongoose();
+    });
+
+    afterEach(function(done) {
+        // safety in the face of assertion failure
+        mongoose.unmock(function() {
+            // AFTER we've put back any spys & stubs
+            sandbox.restore();
+
+            // patiently wait for mongod to shut down
+            //   or else we can't guarantee `MOCK_OPTIONS.port` across tests
+            setTimeout(done, 200);
+        });
+    });
+
+
+    describe('reset', function() {
+        var Collection = mongooseLib.Collection;
+        var collections;
+        var connection;
+
+        beforeEach(function() {
+            mockgoose(mongoose, MOCK_OPTIONS);
+
+            collections = [];
+            sandbox.spy(Collection.prototype, 'deleteMany');
+        });
+
+
+        it('works without any Connections', function(done) {
+            async.series([
+                function(next) {
+                    mockgoose.reset(next);
+                },
+                function(next) {
+                    expect(Collection.prototype.deleteMany.called).to.equal(false);
+
+                    next();
+                },
+            ], done);
+        });
+
+        it('works with one Connection', function(done) {
+            async.series([
+                function(next) {
+                    connection = new Connection(CONNECTION_BASE);
+                    connection.open(HOST, DB, PORT, next);
+                },
+                function(next) {
+                    collections.push(connection.collection('MOE'));
+
+                    mockgoose.reset(next);
+                },
+                function(next) {
+                    expect(Collection.prototype.deleteMany.callCount).to.equal(1);
+
+                    expect(collections.every(function(collection) {
+                        return collection.deleteMany.called;
+                    })).to.equal(true);
+
+                    next();
+                },
+            ], done);
+        });
+
+        it('works with more than one Connection', function(done) {
+            async.series([
+                function(next) {
+                    connection = new Connection(CONNECTION_BASE);
+                    connection.open(HOST, DB, PORT, next);
+                },
+                function(next) {
+                    collections.push(connection.collection('MOE'));
+
+                    connection = new Connection(CONNECTION_BASE);
+                    connection.open(HOST, DB2, PORT, next);
+                },
+                function(next) {
+                    collections.push(connection.collection('JOE'));
+                    collections.push(connection.collection('FLO'));
+
+                    mockgoose.reset(next);
+                },
+                function(next) {
+                    expect(Collection.prototype.deleteMany.callCount).to.equal(3);
+
+                    expect(collections.every(function(collection) {
+                        return collection.deleteMany.called;
+                    })).to.equal(true);
+
+                    next();
+                },
+            ], done);
+        });
+
+        it('does nothing outside of mock-hood', function(done) {
+            async.series([
+                function(next) {
+                    connection = new Connection(CONNECTION_BASE);
+                    connection.open(HOST, DB, PORT, next);
+                },
+                function(next) {
+                    mongoose.unmockAndReconnect(next);
+                },
+                function(next) {
+                    collections.push(connection.collection('MOE'));
+
+                    mockgoose.reset(next);
+                },
+                function(next) {
+                    expect(Collection.prototype.deleteMany.callCount).to.equal(0);
+
+                    next();
+                },
+            ], done);
+        });
+    });
+
+
+    describe('unmock', function() {
+        var openSpy, _openSpy, closeSpy;
+        var connections;
+
+        beforeEach(function() {
+            connections = [];
+
+            openSpy = sandbox.spy(ConnectionPrototype, 'open');
+            _openSpy = sandbox.spy(ConnectionPrototype, '_open');
+            closeSpy = sandbox.spy(ConnectionPrototype, 'close');
+
+            // AFTER we apply the spys
+            mockgoose(mongoose, MOCK_OPTIONS);
+
+            expect(mongoose.isMocked).to.equal(true);
+            expect(ConnectionPrototype.open).to.not.equal(openSpy);
+            expect(ConnectionPrototype._open).to.not.equal(_openSpy);
+        });
+
+
+        it('exists on `mongoose`', function() {
+            expect(mongoose.unmock).to.be.instanceof(Function);
+        });
+
+        it('works without any Connections', function(done) {
+            async.series([
+                function(next) {
+                    mongoose.unmock(next);
+                },
+                function(next) {
+                    // look!  back to normal
+                    expect(mongoose.isMocked).to.equal(undefined);
+                    expect(ConnectionPrototype.open).to.equal(openSpy);
+                    expect(ConnectionPrototype._open).to.equal(_openSpy);
+
+                    expect(closeSpy.called).to.equal(false);
+
+                    next();
+                },
+            ], done);
+        });
+
+        it('works with Connections', function(done) {
+            async.series([
+                function(next) {
+                    connections.push(new Connection(CONNECTION_BASE));
+                    connections[0].open(HOST, DB, PORT, next);
+                },
+                function(next) {
+                    connections.push(new Connection(CONNECTION_BASE));
+                    connections[1].open(HOST, DB2, PORT, next);
+                },
+                function(next) {
+                    connections.forEach(function(connection) {
+                        expect(connection.host).to.equal(MOCK_HOST);
+                        expect(connection.port).to.equal(MOCK_OPTIONS.port);
+                        expect(connection.readyState).to.equal(mongoose.STATES.connected);
+                    });
+
+                    mongoose.unmock(next);
+                },
+                function(next) {
+                    expect(openSpy.callCount).to.equal(2);
+                    expect(_openSpy.callCount).to.equal(2);
+                    expect(closeSpy.callCount).to.equal(2);
+
+                    connections.forEach(function(connection) {
+                        expect(connection.readyState).to.equal(mongoose.STATES.disconnected);
+                    });
+
+                    next();
+                },
+            ], done);
+        });
+
+        it('is cool being called outside of mock-hood', function(done) {
+            async.series([
+                function(next) {
+                    connections.push(new Connection(CONNECTION_BASE));
+                    connections[0].open(HOST, DB, PORT, next);
+                },
+                function(next) {
+                    mongoose.unmock(next);
+                },
+                function(next) {
+                    expect(mongoose.isMocked).to.equal(undefined);
+
+                    mongoose.unmock(next);
+                },
+            ], done);
+        });
+
+        it('is cool being called without a callback', function() {
+            mongoose.unmock();
+        });
+    });
+
+
+    describe('unmockAndReconnect', function() {
+        if (! process.env.MOCKGOOSE_LIVE) {
+            return;
+        }
+
+
+        var openSpy, _openSpy, closeSpy;
+        var connections;
+
+        beforeEach(function() {
+            connections = [];
+
+            openSpy = sandbox.spy(ConnectionPrototype, 'open');
+            _openSpy = sandbox.spy(ConnectionPrototype, '_open');
+            closeSpy = sandbox.spy(ConnectionPrototype, 'close');
+        });
+
+
+        it('exists on `mongoose`', function() {
+            mockgoose(mongoose, MOCK_OPTIONS);
+
+            expect(mongoose.unmockAndReconnect).to.be.instanceof(Function);
+        });
+
+        it('works without any Connections', function(done) {
+            // AFTER we apply the spys
+            mockgoose(mongoose, MOCK_OPTIONS);
+
+            async.series([
+                function(next) {
+                    mongoose.unmockAndReconnect(next);
+                },
+                function(next) {
+                    // look!  back to normal
+                    expect(mongoose.isMocked).to.equal(undefined);
+                    expect(ConnectionPrototype.open).to.equal(openSpy);
+                    expect(ConnectionPrototype._open).to.equal(_openSpy);
+
+                    expect(openSpy.called).to.equal(false);
+                    expect(_openSpy.called).to.equal(false);
+                    expect(closeSpy.called).to.equal(false);
+
+                    next();
+                },
+            ], done);
+        });
+
+        it('works with Connections', function(done) {
+            mockgoose(mongoose, MOCK_OPTIONS);
+
+            async.series([
+                function(next) {
+                    connections.push(new Connection(CONNECTION_BASE));
+                    connections[0].open(HOST, DB, PORT, next);
+                },
+                function(next) {
+                    connections.push(new Connection(CONNECTION_BASE));
+                    connections[1].open(HOST, DB2, PORT, next);
+                },
+                function(next) {
+                    connections.forEach(function(connection) {
+                        expect(connection.host).to.equal(MOCK_HOST);
+                        expect(connection.port).to.equal(MOCK_OPTIONS.port);
+                        expect(connection.readyState).to.equal(mongoose.STATES.connected);
+                    });
+
+                    mongoose.unmockAndReconnect(next);
+                },
+                function(next) {
+                    expect(openSpy.callCount).to.equal(4);
+                    expect(_openSpy.callCount).to.equal(4);
+                    expect(closeSpy.callCount).to.equal(2);
+
+                    connections.forEach(function(connection) {
+                        expect(connection.host).to.equal(HOST);
+                        expect(connection.port).to.equal(PORT);
+                        expect(connection.readyState).to.equal(mongoose.STATES.connected);
+                    });
+
+                    next();
+                },
+            ], done);
+        });
+
+        it('completes when Connections Error upon reconnect', function(done) {
+            // we have non-standard plans for you ...
+            openSpy.restore();
+
+            var startThrowing;
+            var originalOpen = ConnectionPrototype.open;
+            var openStub = sandbox.stub(ConnectionPrototype, 'open', function(
+                // yes, there are many call signatures in the Mongoose code,
+                //   but this is the only one we actually use below
+                host, db, port, cb
+            ) {
+                if (startThrowing) {
+                    return cb(new Error('thrown for ' + db));
+                }
+                originalOpen.apply(this, arguments);
+            });
+
+            // AFTER we apply the spys
+            mockgoose(mongoose, MOCK_OPTIONS);
+
+            async.series([
+                function(next) {
+                    connections.push(new Connection(CONNECTION_BASE));
+                    connections[0].open(HOST, DB, PORT, next);
+                },
+                function(next) {
+                    connections.push(new Connection(CONNECTION_BASE));
+                    connections[1].open(HOST, DB2, PORT, next);
+                },
+                function(next) {
+                    connections.forEach(function(connection) {
+                        expect(connection.host).to.equal(MOCK_HOST);
+                        expect(connection.port).to.equal(MOCK_OPTIONS.port);
+                        expect(connection.readyState).to.equal(mongoose.STATES.connected);
+                    });
+
+                    // it's all downhill from here
+                    startThrowing = true;
+
+                    mongoose.unmockAndReconnect(next);
+                },
+            ], function(err) {
+                // the first one
+                expect(err.message).to.equal('thrown for ' + DB);
+
+                expect(openSpy.callCount).to.equal(0);
+                expect(openStub.callCount).to.equal(4);
+                expect(_openSpy.callCount).to.equal(2);
+                expect(closeSpy.callCount).to.equal(2);
+
+                connections.forEach(function(connection) {
+                    expect(connection.readyState).to.equal(mongoose.STATES.disconnected);
+                });
+
+                // the Test Case will fail on multipe calls to done if we haven't crafted our code right
+                done();
+            });
+        });
+
+        it('is cool being called outside of mock-hood', function(done) {
+            mockgoose(mongoose, MOCK_OPTIONS);
+
+            async.series([
+                function(next) {
+                    connections.push(new Connection(CONNECTION_BASE));
+                    connections[0].open(HOST, DB, PORT, next);
+                },
+                function(next) {
+                    mongoose.unmock(next);
+                },
+                function(next) {
+                    expect(mongoose.isMocked).to.equal(undefined);
+
+                    mongoose.unmockAndReconnect(next);
+                },
+            ], done);
+        });
+
+        it('is cool being called without a callback', function() {
+            mockgoose(mongoose, MOCK_OPTIONS);
+
+            mongoose.unmockAndReconnect();
+        });
+    });
+});

--- a/test/permutations.js
+++ b/test/permutations.js
@@ -19,9 +19,14 @@ var DB = 'DB';
 var DB2 = 'DB2';
 var PORT = 27017;
 var MOCK_HOST = 'localhost';
-var MOCK_OPTIONS = {
+
+// FIXME: avoiding the default :27017
+var FIXME_OPTIONS = {
     port: 27027
 };
+// FIXME: patiently wait for mongod to shut down
+//   or else we can't guarantee :27017 across tests
+var FIXME_INTER_TEST_DELAY = 1000;
 
 
 describe('mockgoose', function() {
@@ -35,9 +40,7 @@ describe('mockgoose', function() {
             // AFTER we've put back any spys & stubs
             sandbox.restore();
 
-            // patiently wait for mongod to shut down
-            //   or else we can't guarantee `MOCK_OPTIONS.port` across tests
-            setTimeout(done, 200);
+            setTimeout(done, FIXME_INTER_TEST_DELAY);
         });
     });
 
@@ -48,7 +51,7 @@ describe('mockgoose', function() {
         var connection;
 
         beforeEach(function() {
-            mockgoose(mongoose, MOCK_OPTIONS);
+            mockgoose(mongoose, FIXME_OPTIONS);
 
             collections = [];
             sandbox.spy(Collection.prototype, 'deleteMany');
@@ -122,6 +125,11 @@ describe('mockgoose', function() {
         });
 
         it('does nothing outside of mock-hood', function(done) {
+            if (! process.env.MOCKGOOSE_LIVE) {
+                return done();
+            }
+
+
             async.series([
                 function(next) {
                     connection = new Connection(CONNECTION_BASE);
@@ -157,7 +165,7 @@ describe('mockgoose', function() {
             closeSpy = sandbox.spy(ConnectionPrototype, 'close');
 
             // AFTER we apply the spys
-            mockgoose(mongoose, MOCK_OPTIONS);
+            mockgoose(mongoose, FIXME_OPTIONS);
 
             expect(mongoose.isMocked).to.equal(true);
             expect(ConnectionPrototype.open).to.not.equal(openSpy);
@@ -200,7 +208,7 @@ describe('mockgoose', function() {
                 function(next) {
                     connections.forEach(function(connection) {
                         expect(connection.host).to.equal(MOCK_HOST);
-                        expect(connection.port).to.equal(MOCK_OPTIONS.port);
+                        expect(connection.port).to.equal(FIXME_OPTIONS.port);
                         expect(connection.readyState).to.equal(mongoose.STATES.connected);
                     });
 
@@ -262,14 +270,14 @@ describe('mockgoose', function() {
 
 
         it('exists on `mongoose`', function() {
-            mockgoose(mongoose, MOCK_OPTIONS);
+            mockgoose(mongoose, FIXME_OPTIONS);
 
             expect(mongoose.unmockAndReconnect).to.be.instanceof(Function);
         });
 
         it('works without any Connections', function(done) {
             // AFTER we apply the spys
-            mockgoose(mongoose, MOCK_OPTIONS);
+            mockgoose(mongoose, FIXME_OPTIONS);
 
             async.series([
                 function(next) {
@@ -291,7 +299,7 @@ describe('mockgoose', function() {
         });
 
         it('works with Connections', function(done) {
-            mockgoose(mongoose, MOCK_OPTIONS);
+            mockgoose(mongoose, FIXME_OPTIONS);
 
             async.series([
                 function(next) {
@@ -305,7 +313,7 @@ describe('mockgoose', function() {
                 function(next) {
                     connections.forEach(function(connection) {
                         expect(connection.host).to.equal(MOCK_HOST);
-                        expect(connection.port).to.equal(MOCK_OPTIONS.port);
+                        expect(connection.port).to.equal(FIXME_OPTIONS.port);
                         expect(connection.readyState).to.equal(mongoose.STATES.connected);
                     });
 
@@ -345,7 +353,7 @@ describe('mockgoose', function() {
             });
 
             // AFTER we apply the spys
-            mockgoose(mongoose, MOCK_OPTIONS);
+            mockgoose(mongoose, FIXME_OPTIONS);
 
             async.series([
                 function(next) {
@@ -359,7 +367,7 @@ describe('mockgoose', function() {
                 function(next) {
                     connections.forEach(function(connection) {
                         expect(connection.host).to.equal(MOCK_HOST);
-                        expect(connection.port).to.equal(MOCK_OPTIONS.port);
+                        expect(connection.port).to.equal(FIXME_OPTIONS.port);
                         expect(connection.readyState).to.equal(mongoose.STATES.connected);
                     });
 
@@ -387,7 +395,7 @@ describe('mockgoose', function() {
         });
 
         it('is cool being called outside of mock-hood', function(done) {
-            mockgoose(mongoose, MOCK_OPTIONS);
+            mockgoose(mongoose, FIXME_OPTIONS);
 
             async.series([
                 function(next) {
@@ -406,7 +414,7 @@ describe('mockgoose', function() {
         });
 
         it('is cool being called without a callback', function() {
-            mockgoose(mongoose, MOCK_OPTIONS);
+            mockgoose(mongoose, FIXME_OPTIONS);
 
             mongoose.unmockAndReconnect();
         });

--- a/test/use-cases.js
+++ b/test/use-cases.js
@@ -1,0 +1,284 @@
+'use strict';
+
+var expect = require('chai').expect;
+var async = require('async');
+
+var Mongoose = require('mongoose').Mongoose;
+var mockgoose = require('../Mockgoose');
+
+var mongoose;
+var Cat;
+
+var HOST = '127.0.0.1'; // because `process.env.MOCKGOOSE_LIVE`
+var DB = 'DB';
+var PORT = 27017;
+var MOCK_OPTIONS = {
+    port: 27027
+};
+
+
+describe('mockgoose', function() {
+    beforeEach(function() {
+        mongoose = new Mongoose();
+
+        mockgoose(mongoose, MOCK_OPTIONS);
+    });
+
+    afterEach(function(done) {
+        // safety in the face of assertion failure
+        mongoose.unmock(function() {
+            // patiently wait for mongod to shut down
+            //   or else we can't guarantee `MOCK_OPTIONS.port` across tests
+            setTimeout(done, 200);
+        });
+    });
+
+
+    describe('reset', function() {
+        describe('after Mongoose#connect', function() {
+            it('resets a Collection', function(done) {
+                var cat;
+
+                async.waterfall([
+                    function(next) {
+                        mongoose.connect(HOST, DB, PORT, next);
+                    },
+                    function(next) {
+                        Cat = mongoose.model('Cat', { name: String });
+
+                        Cat.create({ name: 'Disco' }, next);
+                    },
+                    function(_cat, next) {
+                        cat = _cat;
+
+                        Cat.findById(cat._id, next);
+                    },
+                    function(_cat, next) {
+                        expect(_cat.name).to.equal('Disco'); // good girl!
+
+                        mockgoose.reset(next);
+                    },
+                    function(next) {
+                        Cat.findById(cat._id, next);
+                    },
+                    function(_cat, next) {
+                        // kitty was reset
+                        expect(_cat).to.equal(null);
+
+                        next();
+                    },
+                ], done);
+            });
+        });
+
+        describe('after Mongoose#createConnection + Connection#open', function() {
+            it('resets a Collection', function(done) {
+                var connection;
+                var cat;
+
+                async.waterfall([
+                    function(next) {
+                        connection = mongoose.createConnection();
+                        connection.open(HOST, DB, PORT, next);
+                    },
+                    function(next) {
+                        Cat = connection.model('Cat', { name: String });
+
+                        cat = (new Cat({ name: 'Warhol' }));
+                        cat.save(next);
+                    },
+                    function(_cat, status, next) {
+                        Cat.findById(cat._id, next);
+                    },
+                    function(_cat, next) {
+                        expect(_cat.name).to.equal('Warhol'); // good boy!
+
+                        mockgoose.reset(next);
+                    },
+                    function(next) {
+                        Cat.findById(cat._id, next);
+                    },
+                    function(_cat, next) {
+                        // kitty was reset
+                        expect(_cat).to.equal(null);
+
+                        next();
+                    },
+                ], done);
+            });
+        });
+    });
+
+
+    describe('unmock + re-mock', function() {
+        describe('after Mongoose#connect', function() {
+            it('gets a fresh empty database', function(done) {
+                var cat;
+
+                async.waterfall([
+                    function(next) {
+                        mongoose.connect(HOST, DB, PORT, next);
+                    },
+                    function(next) {
+                        Cat = mongoose.model('Cat', { name: String });
+
+                        Cat.create({ name: 'Disco' }, next);
+                    },
+                    function(_cat, next) {
+                        cat = _cat;
+
+                        Cat.findById(cat._id, next);
+                    },
+                    function(_cat, next) {
+                        expect(_cat.name).to.equal('Disco'); // good girl!
+
+                        mongoose.unmock(next);
+                    },
+                    function(next) {
+                        mockgoose(mongoose, MOCK_OPTIONS);
+
+                        mongoose.connect(HOST, DB, PORT, next);
+                    },
+                    function(next) {
+                        // // "Cannot overwrite `Cat` model once compiled."
+                        // Cat = mongoose.model('Cat', { name: String });
+
+                        Cat.findById(cat._id, next);
+                    },
+                    function(_cat, next) {
+                        // kitty was left in the prior mock database
+                        expect(_cat).to.equal(null);
+
+                        next();
+                    },
+                ], done);
+            });
+        });
+
+        describe('after Mongoose#createConnection + Connection#open', function() {
+            it('gets a fresh empty database', function(done) {
+                var connection;
+                var cat;
+
+                async.waterfall([
+                    function(next) {
+                        connection = mongoose.createConnection();
+                        connection.open(HOST, DB, PORT, next);
+                    },
+                    function(next) {
+                        Cat = connection.model('Cat', { name: String });
+
+                        cat = (new Cat({ name: 'Warhol' }));
+                        cat.save(next);
+                    },
+                    function(_cat, status, next) {
+                        Cat.findById(cat._id, next);
+                    },
+                    function(_cat, next) {
+                        expect(_cat.name).to.equal('Warhol'); // good boy!
+
+                        mongoose.unmock(next);
+                    },
+                    function(next) {
+                        mockgoose(mongoose, MOCK_OPTIONS);
+
+                        connection = mongoose.createConnection();
+                        connection.open(HOST, DB, PORT, next);
+                    },
+                    function(next) {
+                        Cat = connection.model('Cat', { name: String });
+
+                        Cat.findById(cat._id, next);
+                    },
+                    function(_cat, next) {
+                        // kitty was left in the prior mock database
+                        expect(_cat).to.equal(null);
+
+                        next();
+                    },
+                ], done);
+            });
+        });
+    });
+
+
+    describe('unmockAndReconnect', function() {
+        if (! process.env.MOCKGOOSE_LIVE) {
+            return;
+        }
+
+
+        describe('after Mongoose#connect', function() {
+            it('finds nothing in the "real" database', function(done) {
+                var cat;
+
+                async.waterfall([
+                    function(next) {
+                        mongoose.connect(HOST, DB, PORT, next);
+                    },
+                    function(next) {
+                        Cat = mongoose.model('Cat', { name: String });
+
+                        Cat.create({ name: 'Disco' }, next);
+                    },
+                    function(_cat, next) {
+                        cat = _cat;
+
+                        Cat.findById(cat._id, next);
+                    },
+                    function(_cat, next) {
+                        expect(_cat.name).to.equal('Disco'); // good girl!
+
+                        mongoose.unmockAndReconnect(next);
+                    },
+                    function(next) {
+                        Cat.findById(cat._id, next);
+                    },
+                    function(_cat, next) {
+                        // kitty was never saved to the "real" database
+                        expect(_cat).to.equal(null);
+
+                        next();
+                    },
+                ], done);
+            });
+        });
+
+        describe('after Mongoose#createConnection + Connection#open', function() {
+            it('finds nothing in the "real" database', function(done) {
+                var connection;
+                var cat;
+
+                async.waterfall([
+                    function(next) {
+                        connection = mongoose.createConnection();
+                        connection.open(HOST, DB, PORT, next);
+                    },
+                    function(next) {
+                        Cat = connection.model('Cat', { name: String });
+
+                        cat = (new Cat({ name: 'Warhol' }));
+                        cat.save(next);
+                    },
+                    function(_cat, status, next) {
+                        Cat.findById(cat._id, next);
+                    },
+                    function(_cat, next) {
+                        expect(_cat.name).to.equal('Warhol'); // good boy!
+
+                        mongoose.unmockAndReconnect(next);
+                    },
+                    function(next) {
+                        Cat.findById(cat._id, next);
+                    },
+                    function(_cat, next) {
+                        // kitty was never saved to the "real" database
+                        expect(_cat).to.equal(null);
+
+                        next();
+                    },
+                ], done);
+            });
+        });
+    });
+});

--- a/test/use-cases.js
+++ b/test/use-cases.js
@@ -12,24 +12,27 @@ var Cat;
 var HOST = '127.0.0.1'; // because `process.env.MOCKGOOSE_LIVE`
 var DB = 'DB';
 var PORT = 27017;
-var MOCK_OPTIONS = {
+
+// FIXME: avoiding the default :27017
+var FIXME_OPTIONS = {
     port: 27027
 };
+// FIXME: patiently wait for mongod to shut down
+//   or else we can't guarantee :27017 across tests
+var FIXME_INTER_TEST_DELAY = 1000;
 
 
 describe('mockgoose', function() {
     beforeEach(function() {
         mongoose = new Mongoose();
 
-        mockgoose(mongoose, MOCK_OPTIONS);
+        mockgoose(mongoose, FIXME_OPTIONS);
     });
 
     afterEach(function(done) {
         // safety in the face of assertion failure
         mongoose.unmock(function() {
-            // patiently wait for mongod to shut down
-            //   or else we can't guarantee `MOCK_OPTIONS.port` across tests
-            setTimeout(done, 200);
+            setTimeout(done, FIXME_INTER_TEST_DELAY);
         });
     });
 
@@ -135,7 +138,7 @@ describe('mockgoose', function() {
                         mongoose.unmock(next);
                     },
                     function(next) {
-                        mockgoose(mongoose, MOCK_OPTIONS);
+                        mockgoose(mongoose, FIXME_OPTIONS);
 
                         mongoose.connect(HOST, DB, PORT, next);
                     },
@@ -180,7 +183,7 @@ describe('mockgoose', function() {
                         mongoose.unmock(next);
                     },
                     function(next) {
-                        mockgoose(mongoose, MOCK_OPTIONS);
+                        mockgoose(mongoose, FIXME_OPTIONS);
 
                         connection = mongoose.createConnection();
                         connection.open(HOST, DB, PORT, next);


### PR DESCRIPTION
**thank you guys** for an awesome project and code foundation -- you've provided an excellent strategy for mocking MongoDB, and we'd like to contribute to its ongoing health

what our team needed is documented in #182 

> Mockgoose only intercepts `mongoose.connect`.  the monkey-patching strategy already implemented  in Mockgoose could be moved down to the more immediate Connection level, closer to what it's trying to emulate

 i have provided a solution

- migrated mongoose.connect logic => Connection#open
- support unmock, unmockAndReconnect
- no API changes -- it's a PATCH :)
- Test Suite assertions

## so,

**hello**.  you guys don't know me, and here i come along and *mess with all your stuffs*

my employer's Dev org really appreciates having a solid set-it-and-forget-it solution for MongoDB mocking.  Mockgoose has been that solution.  with recent upgrades, we found that we were having compatability issues.  and i decided to go ahead and fix them

as you can see, this was a major re-factoring Job.  i "simply" moved your existing intercepting monkey-patch paradigms down into the Connection code.  it's my opinion that the intercepting strategy itself remains un-changed by the refactor

i have added 3 new Test Suite files.  they exercise the new logic in gory detail.  there are still other issues with the codebase, but they are beyond the scope of what i was attempting to do -- and i already attempted a whole heck of a lot ... folks can get to fixing those other issues later ...

the new implementation provides the exact same functionality as before, so i believe Semver-wise it is a PATCH.  but that's going to be a hard sell given the degree of change.  however, i have built it to operate as a PATCH

again, this is totally out of the blue, guys.  i welcome your feedback