### PR TITLE
Improve startup logging

### DIFF
--- a/Mockgoose.js
+++ b/Mockgoose.js
@@ -115,16 +115,32 @@ module.exports = function(mongoose, db_opts) {
                     } catch (e) {
                         if (e.code !== "EEXIST" ) throw e;
                     }
-
-                    mongod_emitter = mongod.start_server({args: db_opts, auto_shutdown: true}, function(err) {
+        
+                    var starting_up = true, startup_log_buffer = '';
+                    function logs_callback(buffer) {
+                        if (starting_up) {
+                            startup_log_buffer += buffer;
+                        }
+                    }
+            
+                    var server_opts = {args: db_opts, auto_shutdown: true, logs_callback: logs_callback};
+                    mongod_emitter = mongod.start_server(server_opts, function(err) {
                         if (!err) {
+                            starting_up = false;
+                            debug('Started up MongoDB successfully');
                             emitter.emit('mongodbStarted', db_opts);
                         } else {
-                            db_opts.port++;
-                            start_server(db_opts);
+                            debug(startup_log_buffer);
+                            debug('Error starting server.');
+                            if (err.code === 'EADDRINUSE') {
+                                debug('Address in use. Trying alternative port...');
+                                db_opts.port++;
+                                startup_log_buffer = '';
+                                start_server(db_opts);
+                            }
                         }
                     });
-                });        
+                });
             }
         );
     }


### PR DESCRIPTION
These are some logging improvements I made when working on https://github.com/winfinit/mongodb-prebuilt/pull/8, can be merged to Mockgoose now that it's been updated to use the newer version of mongodb-prebuilt that includes the above changes.

The changes in this PR are:
- Write startup output to the debug log so failures are more visible
- Only retry with a different port if the failure was due to the port being in use (the pull request mentioned above alters mongodb-prebuilt to detect this case more reliably), otherwise you get into an infinite loop