### PR TITLE
hotfix for start_server callback

### DIFF
--- a/Mockgoose.js
+++ b/Mockgoose.js
@@ -141,7 +141,14 @@ module.exports = function(mongoose, db_opts) {
                     auto_shutdown: true
                 };
 
-                var startResult = mongod.start_server(server_opts);
+                var startResult = mongod.start_server(server_opts, function(response) {
+                    // This is a bad callback that should be fixed in mongodb-prebuilt (issue #12).
+                    // It's only called when there's an error or non-zero child process status code.
+                    // 'response' can be an error OR the process status code.
+                    // The child process status code is always returned, so keep using startResult until the issue resolves.
+                    // This callback is required so start_server doesn't crash trying to call undefined as a function.
+                    debug('mongod.start_server callback called: ' + response);
+                });
                 if (startResult === 0) {
                     debug('mongod.start_server connected');
                     var mock_uri = "mongodb://localhost:" + db_opts.port;


### PR DESCRIPTION
Since this should be a temporary fix, I added a bunch of comments to explain the situation.
This will need updating once start_server (https://github.com/winfinit/mongodb-prebuilt/blob/master/index.js#L35-L100) does one of the following.
- Uses the callback everywhere (specifically here https://github.com/winfinit/mongodb-prebuilt/blob/master/index.js#L98)
  -- If the callback is reliably called, we can use a callback only instead of both callback and the startResult if/else
- Checks that a callback exists before calling
  -- If start_server looked before it leapt, we could continue to use startResult and not have to pass a dummy function.

I'd like it all to move to callbacks, but either way works.
