### PR TITLE
Use once to avoid emitter leaks on close

### DIFF
--- a/Mockgoose.js
+++ b/Mockgoose.js
@@ -92,7 +92,7 @@ module.exports = function(mongoose, db_opts) {
 
         mongoose.isMocked = true;
 
-        mongoose.connection.on('disconnected', function() {
+        mongoose.connection.once('disconnected', function() {
             debug('Mongoose disconnected');
         });
         deferred.resolve(mockgoose_uri);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mockgoose",
   "description": "Mockgoose is an in memory database mock to allow for testing of applications that rely on Mongoose.",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "author": {
     "name": "Anthony McCormick",
     "email": "anthony.mccormick AT gmail.com"


### PR DESCRIPTION
Used to solve this error:
```
.(node) warning: possible EventEmitter memory leak detected. 11 disconnected listeners added. Use emitter.setMaxListeners() to increase limit.
Trace
    at NativeConnection.addListener (events.js:239:17)
    at /home/prj/node_modules/mockgoose/Mockgoose.js:95:29
    at /home/prj/node_modules/mockgoose/Mockgoose.js:148:21
    at next (/home/prj/node_modules/mockgoose/node_modules/rimraf/rimraf.js:74:7)
    at FSReqWrap.CB [as oncomplete] (/home/prj/node_modules/mockgoose/node_modules/rimraf/rimraf.js:110:9)
```

while used with jasmine : 
```
  beforeEach(function(done) {
    require('../models/customers')();
    mockgoose(mongoose).then(function() {
      mongoose.connect('mongodb://example.com/TestingDB', function(err) {
        done(err);
      });
    });
  });

  afterEach(function(done) {
    mockgoose.reset(function() {
      mongoose.unmock(function() {
        mongoose.disconnect();
        delete mongoose.models.Customer;
        done();
      });
    });
  });
```