### PR TITLE
shutdown Mongo on unmock

### DIFF
--- a/Mockgoose.js
+++ b/Mockgoose.js
@@ -168,6 +168,7 @@ module.exports = function(mongoose, db_opts) {
             delete mongoose.isMocked;
             connect_args[0] = orig_connect_uri;
             mongoose.connect = orig_connect;
+            mongod.shutdown();
             callback();
         });
     };


### PR DESCRIPTION
Actually mongodb-prebuilt is still active until the node process dies, even if it was unmocked. 

This patch force a shutdown on unmock, killing the mongodb-prebuilt process.
It needs https://github.com/winfinit/mongodb-prebuilt/pull/28 to work