### PR TITLE
Fixes Issue 227 Reset failing for createConnection

### DIFF
--- a/Mockgoose.js
+++ b/Mockgoose.js
@@ -164,36 +164,23 @@ module.exports = function(mongoose, db_opts) {
                 dbs.push(connection.db);
             }
         });
-        if (dbs.length > 0) {
-            (function dropDatabase(index){
-                if (dbs[index]._listening !== true) {
+        (function dropDatabase(index){
+            if (dbs[index] === undefined || dbs[index]._listening !== true) {
+                if (isCallback === true) {
+                    return done();
+                }
+                return;
+            }
+            dbs[index].dropDatabase(function(err) {
+                if (err) {
                     if (isCallback === true) {
-                        return done();
+                        return done(err);
                     }
                     return;
                 }
-                dbs[index].dropDatabase(function(err) {
-                    if (err) {
-                        if (isCallback === true) {
-                            return done(err);
-                        }
-                        return;
-                    }
-                    if (index + 1 === dbs.length) {
-                        if (isCallback === true) {
-                            return done();
-                        }
-                        return;
-                    }
-                    dropDatabase(index + 1);
-                });
-            }(0));
-        } else {
-            if (isCallback === true) {
-                return done();
-            }
-            return;
-        }
+                dropDatabase(index + 1);
+            });
+        }(0));
     };
 
     mongoose.unmock = function(callback) {

--- a/Mockgoose.js
+++ b/Mockgoose.js
@@ -120,10 +120,10 @@ module.exports = function(mongoose, db_opts) {
                 when in place upgrade is done of mongodb,
                 we need to clean directory first, otherwise
                 this error is returned:
-                    exception in initAndListen: 28662 Cannot start server. 
-                    Detected data files in /Mockgoose/.mongooseTempDB/27017 
-                    created by the 'inMemoryExperiment' storage engine, 
-                    but the specified storage engine was 'ephemeralForTest'., 
+                    exception in initAndListen: 28662 Cannot start server.
+                    Detected data files in /Mockgoose/.mongooseTempDB/27017
+                    created by the 'inMemoryExperiment' storage engine,
+                    but the specified storage engine was 'ephemeralForTest'.,
                     terminating
             */
             rimraf(db_opts.dbpath, function(err) {
@@ -156,11 +156,26 @@ module.exports = function(mongoose, db_opts) {
     }
 
     module.exports.reset = function(done) {
-        mongoose.connection.db.dropDatabase(function(err) {
-            if (typeof done === "function") {
-                done(err);
+        if (mongoose.connection.db !== undefined) {
+            mongoose.connection.db.dropDatabase(function(err) {
+                if (typeof done === "function") {
+                    return done(err);
+                }
+                return;
+            });
+        }
+        mongoose.connections.forEach(function (connection) {
+            if (connection.db !== undefined) {
+                connection.db.dropDatabase(function (err) {
+                    if (err) {
+                        throw new Error("Error dropping database");
+                    }
+                });
             }
         });
+        if (typeof done === "function") {
+            return done();
+        }
     };
 
     mongoose.unmock = function(callback) {

--- a/Mockgoose.js
+++ b/Mockgoose.js
@@ -165,21 +165,19 @@ module.exports = function(mongoose, db_opts) {
             }
         });
         (function dropDatabase(index){
-            if (dbs[index] === undefined || dbs[index]._listening !== true) {
-                if (isCallback === true) {
-                    return done();
-                }
-                return;
+            if (dbs[index] === undefined) {
+                return (isCallback === true ? done() : true);
             }
-            dbs[index].dropDatabase(function(err) {
-                if (err) {
-                    if (isCallback === true) {
-                        return done(err);
+            if (dbs[index]._listening === true) {
+                dbs[index].dropDatabase(function(err) {
+                    if (err) {
+                        return (isCallback === true ? done(err) : false);
                     }
-                    return;
-                }
+                    dropDatabase(index + 1);
+                });
+            } else {
                 dropDatabase(index + 1);
-            });
+            }
         }(0));
     };
 


### PR DESCRIPTION
The issue was that createConnection and connect stores connections in a connections array, but connect also stores them in a connect object. The method was only checking that object so never worked if connection(s) were created using createConnection. Also, if the method were called when no connections were created, it would fail (silently) which is why there is now a check in place for db._listening.
